### PR TITLE
Self-serve signup with email verification, and make deploys actually migrate

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -163,12 +163,26 @@ jobs:
           # Wait for service to be fully ready
           sleep 10
 
-          # Check if the application is responding
-          if curl -f -s -o /dev/null -w "%{http_code}" https://kanban.pearachute.com/api/health | grep -q "200\|404"; then
-            echo "✅ Application is responding"
+          # This step used to accept "200|404" against /api/health, an
+          # endpoint that did not exist. Undefined /api/... paths fall through
+          # to the SPA catch-all and return 200 with index.html, so the check
+          # passed unconditionally -- a broken database, a 500ing API and an
+          # unmigrated schema all reported success.
+          #
+          # /api/health now exists and queries the database, so a schema or
+          # connection problem surfaces as 503. Match on the JSON body rather
+          # than the status code alone, so the SPA fallback cannot satisfy it
+          # again if the route is ever removed.
+          BODY=$(curl -s --max-time 15 https://kanban.pearachute.com/api/health || true)
+          echo "Health response: $BODY"
+
+          if echo "$BODY" | grep -q '"status":"ok"'; then
+            echo "✅ Application is healthy"
           else
-            echo "❌ Application is not responding"
-            curl -I https://kanban.pearachute.com
+            echo "❌ Health check failed"
+            echo "--- /api/health ---"
+            curl -s -i --max-time 15 https://kanban.pearachute.com/api/health || true
+            echo "--- service logs ---"
             exit 1
           fi
 

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -163,16 +163,18 @@ jobs:
           # Wait for service to be fully ready
           sleep 10
 
-          # This step used to accept "200|404" against /api/health, an
-          # endpoint that did not exist. Undefined /api/... paths fall through
-          # to the SPA catch-all and return 200 with index.html, so the check
-          # passed unconditionally -- a broken database, a 500ing API and an
-          # unmigrated schema all reported success.
+          # This step used to accept "200|404" against /api/health, an endpoint
+          # that did not exist -- so it passed unconditionally and a broken
+          # database, a 500ing API and an unmigrated schema all reported
+          # success. Accepting 404 was enough on its own to make it
+          # unfalsifiable; before main.py started 404ing unmatched /api/ paths,
+          # the SPA catch-all answered them 200 with index.html, which made it
+          # doubly so.
           #
           # /api/health now exists and queries the database, so a schema or
-          # connection problem surfaces as 503. Match on the JSON body rather
-          # than the status code alone, so the SPA fallback cannot satisfy it
-          # again if the route is ever removed.
+          # connection problem surfaces as 503. Match on the JSON body, not the
+          # status code, so removing the route fails the deploy rather than
+          # quietly satisfying it again.
           BODY=$(curl -s --max-time 15 https://kanban.pearachute.com/api/health || true)
           echo "Health response: $BODY"
 

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ env/
 .DS_Store
 node_modules/
 backend/static/
+.claude/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,39 @@ kanban --help
 - `KANBAN_CONFIG_PATH`: Path to config file (default: ~/.kanban.yaml)
 - `KANBAN_API_KEY`: Default API key for authentication
 
+Server-side:
+
+- `RESEND_API_KEY`: Resend key for outbound email. Unset, mail is printed to
+  stderr instead of sent — which is how local development works without a key.
+- `RESEND_FROM`: Sender address (default `Kanban <noreply@kanban.pearachute.com>`).
+  The domain must be verified in Resend.
+- `PUBLIC_BASE_URL`: Origin used to build links in email (default
+  `https://kanban.pearachute.com`).
+
+### Signup and Email Verification
+
+Signup is self-serve and open: `POST /api/signup` takes `{username, email,
+password}` and creates the account with `email_verified=False`, then emails a
+link. `POST /api/token` returns **403 "Email not verified"** until
+`POST /api/verify-email` consumes that token, which also returns a JWT so the
+user lands logged in.
+
+Two things to keep in mind when touching this:
+
+- `User.create_user()` defaults to `email_verified=True`. Admin- and
+  CLI-created accounts are trusted; only the signup endpoint passes False.
+  Flipping that default would make `manage.py user-create` produce accounts
+  that cannot log in.
+- Signup grants no organization access whatsoever. Joining an existing org
+  happens only via an owner calling `POST /organizations/{id}/members` or via
+  an `OrganizationInvite` token. Don't add an org field to signup.
+
+There is no rate limiting anywhere in the stack. The 60-second per-account
+resend cooldown is the only brake on outbound verification mail.
+
+Deploying this needs no manual migration step — `sys/scripts/deploy.sh` now runs
+`manage.py migrate` before restarting the service. See Database Migrations below.
+
 ### Running the Server
 
 ```bash
@@ -74,7 +107,47 @@ python manage.py user-create <username> <password> [--email EMAIL] [--admin]
 
 # Check database status
 python manage.py status
+
+# Apply pending migrations
+python manage.py migrate
+
+# Show what is applied and what is pending, without running anything
+python manage.py migrate --list
 ```
+
+### Database Migrations
+
+Migrations live in `backend/migrations/` and run under **peewee-migrate**.
+`sys/scripts/deploy.sh` calls `manage.py migrate` on every deploy, before the
+service restarts, and a failure aborts the deploy — the service keeps serving
+the old code rather than starting against a schema it does not match.
+
+Applied migrations are recorded in a `migratehistory` table, so running the
+command repeatedly is cheap and safe.
+
+Writing a new one — name it `NNN_description.py` (the three-digit prefix is how
+peewee-migrate finds and orders them) and define:
+
+```python
+def migrate(migrator, database, *, fake=False):
+    ...
+
+def rollback(migrator, database, *, fake=False):
+    ...
+```
+
+Two conventions worth keeping:
+
+- **Make it idempotent.** Check before you alter. Production applied migration
+  001 by hand years before there was a history table, and a fresh install gets
+  most columns from `create_tables()` in `init_db()` — so a migration routinely
+  meets a database that already has some of its changes.
+- **Match peewee's index names.** `create_tables()` names the index for
+  `email = CharField(unique=True)` as `user_email`. A migration that invents its
+  own name leaves fresh installs and migrated databases with different schemas.
+
+`init_db()` still creates *new tables* from the models on startup, so a
+migration only needs to handle columns, indexes and data.
 
 ### Running Tests
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,8 +48,12 @@ Server-side:
 
 - `RESEND_API_KEY`: Resend key for outbound email. Unset, mail is printed to
   stderr instead of sent — which is how local development works without a key.
-- `RESEND_FROM`: Sender address (default `Kanban <noreply@kanban.pearachute.com>`).
-  The domain must be verified in Resend.
+- `RESEND_FROM`: Sender address (default `Kanban <noreply@pearachute.com>`).
+  The domain must be verified in Resend, and a subdomain counts as a separate
+  domain there — hence the apex, which the main pearachute.com site also sends
+  from. Sending from an unverified domain fails every time, silently as far as
+  the user is concerned: signup still succeeds and the rejection only appears
+  in the service log.
 - `PUBLIC_BASE_URL`: Origin used to build links in email (default
   `https://kanban.pearachute.com`).
 

--- a/backend/api.py
+++ b/backend/api.py
@@ -553,6 +553,39 @@ async def resend_verification(
     return generic
 
 
+@api.get("/health")
+async def health():
+    """Liveness check for the deploy pipeline. Public, no auth.
+
+    Deliberately fetches a User row rather than returning a constant. A
+    constant would pass while the schema was unmigrated, which is exactly the
+    outage this is meant to catch.
+
+    It must be .first() and not .count(): peewee compiles .count() to
+    SELECT COUNT(1) FROM (SELECT 1 FROM user LIMIT 1), which names none of the
+    model's columns and therefore happily succeeds against a database missing
+    one. .first() emits the full column list, so a missing column fails here
+    the same way it fails for a real request. Verified against an unmigrated
+    copy of production, where .count() reported healthy while /api/token was
+    raising "no such column: t1.email_verified".
+
+    An empty table is fine -- the SELECT still names every column, so this
+    works on a brand new install with no users.
+
+    Note the endpoint has to exist for the check to mean anything: an
+    undefined /api/... path falls through to the SPA catch-all in main.py and
+    returns 200 with index.html, so a missing endpoint looks healthy.
+    """
+    try:
+        User.select().limit(1).first()
+    except Exception as exc:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=f"Database unavailable: {exc}",
+        )
+    return {"status": "ok"}
+
+
 @api.get("/admin/status")
 async def admin_status(current_user: User = Depends(get_current_user_or_api_key)):
     """Check if current user has admin access"""

--- a/backend/api.py
+++ b/backend/api.py
@@ -928,7 +928,7 @@ async def create_admin_board(
         raise HTTPException(status_code=404, detail="Owner user not found")
 
     board = Board.create_with_columns(
-        owner=owner, name=board_data.name, column_names=[]
+        owner=owner, name=board_data.name
     )
 
     column_count = Column.select().where(Column.board == board).count()
@@ -1006,7 +1006,7 @@ async def create_board(
 ):
     with db.atomic():
         board = Board.create_with_columns(
-            owner=current_user, name=board_data.name, column_names=[]
+            owner=current_user, name=board_data.name
         )
     return {
         "id": board.id,

--- a/backend/api.py
+++ b/backend/api.py
@@ -2,7 +2,7 @@ import re
 from datetime import datetime, timezone
 from typing import Optional
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, status
 from fastapi.responses import PlainTextResponse
 from pydantic import BaseModel, ConfigDict
 import os
@@ -15,6 +15,7 @@ from backend.auth import (
     get_current_admin,
 )
 from backend.database import db
+from backend.mailer import send_invite_email, send_verification_email
 from backend.models import (
     User,
     Board,
@@ -28,9 +29,20 @@ from backend.models import (
     BetaSignup,
     ApiKey,
     OrganizationInvite,
+    EmailVerificationToken,
+    _as_datetime,
 )
 
 api = APIRouter()
+
+EMAIL_PATTERN = r"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$"
+
+# Detail string the frontend keys on to offer "resend verification" instead of
+# a generic login failure. Changing it means changing Login.svelte too.
+UNVERIFIED_EMAIL_DETAIL = "Email not verified"
+
+# Minimum gap between verification emails for one account.
+RESEND_COOLDOWN_SECONDS = 60
 
 
 def slugify(text):
@@ -95,6 +107,20 @@ def get_user_organizations(user):
 class LoginRequest(BaseModel):
     username: str
     password: str
+
+
+class SignupRequest(BaseModel):
+    username: str
+    email: str
+    password: str
+
+
+class VerifyEmailRequest(BaseModel):
+    token: str
+
+
+class ResendVerificationRequest(BaseModel):
+    email: str
 
 
 class UsernameRequest(BaseModel):
@@ -393,8 +419,138 @@ async def login(request: LoginRequest):
             detail="Incorrect username or password",
             headers={"WWW-Authenticate": "Bearer"},
         )
+    # Checked after the password, not before: answering this for anyone who
+    # types a username would leak which accounts exist.
+    if not user.email_verified:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=UNVERIFIED_EMAIL_DETAIL,
+        )
     access_token = create_access_token(data={"sub": user.id, "username": user.username})
     return {"access_token": access_token, "token_type": "bearer"}
+
+
+@api.post("/signup", status_code=status.HTTP_201_CREATED)
+async def signup(request: SignupRequest, background_tasks: BackgroundTasks):
+    """Create an account. Public -- this is the self-serve front door.
+
+    Takes no organization of any kind. A new account joins nothing; org
+    membership comes only from an owner adding you or from accepting an
+    invite token.
+    """
+    username = request.username.strip()
+    email = request.email.strip().lower()
+
+    if not username:
+        raise HTTPException(status_code=400, detail="Username is required")
+    if not re.match(EMAIL_PATTERN, email):
+        raise HTTPException(status_code=400, detail="Invalid email address")
+
+    if User.get_or_none(User.username == username):
+        raise HTTPException(status_code=400, detail="Username is already taken")
+    if User.get_or_none(User.email == email):
+        # Deliberately explicit. It does reveal that an address is registered,
+        # but the alternative -- silently succeeding and mailing the existing
+        # account -- strands people who forgot they signed up. The login page
+        # already discloses the same thing for usernames.
+        raise HTTPException(
+            status_code=400, detail="An account with that email already exists"
+        )
+
+    try:
+        with db.atomic():
+            user = User.create_user(
+                username=username,
+                password=request.password,
+                email=email,
+                email_verified=False,
+            )
+            _, token = EmailVerificationToken.create_for(user)
+    except ValueError as exc:
+        # Raised by create_user past PASSWORD_MAX_LENGTH.
+        raise HTTPException(status_code=400, detail=str(exc))
+
+    background_tasks.add_task(send_verification_email, user, token)
+
+    return {
+        "message": "Account created. Check your email for a verification link.",
+        "email": user.email,
+    }
+
+
+@api.post("/verify-email", response_model=Token)
+async def verify_email(request: VerifyEmailRequest):
+    """Consume a verification token and log the user in.
+
+    POST rather than a GET link target on purpose: mail scanners and link
+    previewers follow GET URLs, which would silently burn the token before the
+    recipient ever clicked it.
+    """
+    record = EmailVerificationToken.get_or_none(
+        EmailVerificationToken.token == request.token
+    )
+    if record is None:
+        raise HTTPException(status_code=404, detail="Invalid verification link")
+    if record.is_used():
+        raise HTTPException(
+            status_code=400, detail="This verification link has already been used"
+        )
+    if record.is_expired():
+        raise HTTPException(
+            status_code=400,
+            detail="This verification link has expired. Request a new one.",
+        )
+
+    user = record.user
+    with db.atomic():
+        record.mark_used()
+        if not user.email_verified:
+            user.email_verified = True
+            user.save()
+
+    access_token = create_access_token(data={"sub": user.id, "username": user.username})
+    return {"access_token": access_token, "token_type": "bearer"}
+
+
+@api.post("/resend-verification")
+async def resend_verification(
+    request: ResendVerificationRequest, background_tasks: BackgroundTasks
+):
+    """Re-send a verification email.
+
+    Always reports the same thing regardless of whether the address is
+    registered or already verified, so this cannot be used to enumerate
+    accounts.
+    """
+    generic = {
+        "message": "If that address needs verifying, we've sent a new link."
+    }
+
+    email = request.email.strip().lower()
+    if not re.match(EMAIL_PATTERN, email):
+        raise HTTPException(status_code=400, detail="Invalid email address")
+
+    user = User.get_or_none(User.email == email)
+    if user is None or user.email_verified:
+        return generic
+
+    latest = (
+        EmailVerificationToken.select()
+        .where(EmailVerificationToken.user == user)
+        .order_by(EmailVerificationToken.created_at.desc())
+        .first()
+    )
+    if latest is not None:
+        age = datetime.now(timezone.utc) - _as_datetime(latest.created_at)
+        if age.total_seconds() < RESEND_COOLDOWN_SECONDS:
+            raise HTTPException(
+                status_code=429,
+                detail="A verification email was just sent. Try again in a minute.",
+            )
+
+    _, token = EmailVerificationToken.create_for(user)
+    background_tasks.add_task(send_verification_email, user, token)
+    return generic
 
 
 @api.get("/admin/status")
@@ -460,6 +616,15 @@ async def update_admin_user(
     )
     if existing:
         raise HTTPException(status_code=400, detail="Username already taken")
+
+    # Email is unique now that accounts are created by verifying one, so this
+    # would otherwise surface as an IntegrityError 500.
+    if user_data.email:
+        existing_email = User.get_or_none(
+            (User.email == user_data.email) & (User.id != user_id)
+        )
+        if existing_email:
+            raise HTTPException(status_code=400, detail="Email already taken")
 
     user.username = user_data.username
     user.email = user_data.email
@@ -1694,6 +1859,7 @@ class InviteResponse(BaseModel):
 async def create_organization_invite(
     org_id: int,
     request: InviteCreateRequest,
+    background_tasks: BackgroundTasks,
     current_user: User = Depends(get_current_user_or_api_key),
 ):
     """Create an invite token for an organization. Owner only."""
@@ -1710,6 +1876,13 @@ async def create_organization_invite(
         created_by=current_user,
         email=request.email,
     )
+
+    # An anonymous invite has nowhere to go -- the owner passes the token along
+    # themselves, which is how this worked before there was a mailer.
+    if invite.email:
+        background_tasks.add_task(
+            send_invite_email, invite.email, token, org.name, current_user.username
+        )
 
     return {
         "id": invite.id,
@@ -2090,11 +2263,7 @@ async def docs_section_markdown(section: str):
 @api.post("/beta-signup")
 async def beta_signup(request: BetaSignupRequest):
     """Register interest for beta access"""
-    import re
-
-    # Basic email validation
-    email_pattern = r"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$"
-    if not re.match(email_pattern, request.email):
+    if not re.match(EMAIL_PATTERN, request.email):
         raise HTTPException(status_code=400, detail="Invalid email address")
 
     # Check if already signed up

--- a/backend/api.py
+++ b/backend/api.py
@@ -589,9 +589,12 @@ async def health():
     An empty table is fine -- the SELECT still names every column, so this
     works on a brand new install with no users.
 
-    Note the endpoint has to exist for the check to mean anything: an
-    undefined /api/... path falls through to the SPA catch-all in main.py and
-    returns 200 with index.html, so a missing endpoint looks healthy.
+    The endpoint has to actually exist for the check to mean anything. It did
+    not when the deploy started curling it, and back then an undefined
+    /api/... path fell through to the SPA catch-all and answered 200 with
+    index.html. main.py now 404s unmatched /api/ paths instead, but the deploy
+    check accepted "200|404" -- so a missing endpoint still read as healthy,
+    just via a different route. Hence matching on the response body.
     """
     try:
         User.select().limit(1).first()

--- a/backend/conftest.py
+++ b/backend/conftest.py
@@ -33,37 +33,16 @@ TEST_MODELS = None
 
 
 def _models():
+    """Every model, imported lazily so DATABASE_PATH above is set first.
+
+    Reads backend.models.ALL_MODELS rather than repeating the list, so a new
+    model cannot be added to the app and silently missed by the test schema.
+    """
     global TEST_MODELS
     if TEST_MODELS is None:
-        from backend.models import (
-            User,
-            Board,
-            Column,
-            Card,
-            Comment,
-            Organization,
-            OrganizationMember,
-            Team,
-            TeamMember,
-            ApiKey,
-            BetaSignup,
-            OrganizationInvite,
-        )
+        from backend.models import ALL_MODELS
 
-        TEST_MODELS = [
-            User,
-            Board,
-            Column,
-            Card,
-            Comment,
-            Organization,
-            OrganizationMember,
-            Team,
-            TeamMember,
-            ApiKey,
-            BetaSignup,
-            OrganizationInvite,
-        ]
+        TEST_MODELS = ALL_MODELS
     return TEST_MODELS
 
 
@@ -86,39 +65,12 @@ def _setup_test_db():
 @pytest.fixture
 def db_session(_setup_test_db):
     """Per-test database fixture that clears all data between tests."""
-    from backend.models import (
-        User,
-        Board,
-        Column,
-        Card,
-        Comment,
-        Organization,
-        OrganizationMember,
-        Team,
-        TeamMember,
-        ApiKey,
-        BetaSignup,
-        OrganizationInvite,
-    )
-
-    # Clear all table data using peewee's delete method
-    for table in [
-        Card,
-        Comment,
-        Column,
-        Board,
-        TeamMember,
-        Team,
-        OrganizationMember,
-        Organization,
-        ApiKey,
-        BetaSignup,
-        OrganizationInvite,
-        User,
-    ]:
+    # Reversed, so children go before the parents they reference. ALL_MODELS is
+    # ordered parents-first for create_tables; deletion wants the opposite.
+    for table in reversed(_models()):
         try:
             table.delete().execute()
-        except:
+        except Exception:
             pass
     yield _db
 

--- a/backend/database.py
+++ b/backend/database.py
@@ -15,35 +15,7 @@ def init_db():
         return
 
     db.connect()
-    from backend.models import (
-        User,
-        Board,
-        Column,
-        Card,
-        Comment,
-        Organization,
-        OrganizationMember,
-        Team,
-        TeamMember,
-        BetaSignup,
-        ApiKey,
-        OrganizationInvite,
-    )
+    from backend.models import ALL_MODELS
 
-    db.create_tables(
-        [
-            User,
-            Board,
-            Column,
-            Card,
-            Comment,
-            Organization,
-            OrganizationMember,
-            Team,
-            TeamMember,
-            BetaSignup,
-            ApiKey,
-            OrganizationInvite,
-        ]
-    )
+    db.create_tables(ALL_MODELS)
     db.close()

--- a/backend/mailer.py
+++ b/backend/mailer.py
@@ -23,7 +23,13 @@ SEND_TIMEOUT_SECONDS = 10
 
 
 def _from_address() -> str:
-    return os.environ.get("RESEND_FROM", "Kanban <noreply@kanban.pearachute.com>")
+    # pearachute.com, not kanban.pearachute.com. In Resend a subdomain is a
+    # separate domain with its own DKIM records, and only the apex is
+    # verified -- it is also what the pearachute.com site sends from, so both
+    # apps share one verified domain. A default pointing at an unverified
+    # subdomain would have every send rejected while signup still succeeded,
+    # visible only in the service log.
+    return os.environ.get("RESEND_FROM", "Kanban <noreply@pearachute.com>")
 
 
 def public_base_url() -> str:

--- a/backend/mailer.py
+++ b/backend/mailer.py
@@ -1,0 +1,129 @@
+"""Outbound email, via Resend's HTTP API.
+
+Named mailer.py rather than email.py so it cannot be confused with the stdlib
+``email`` package that requests and friends import internally.
+
+Sending is best-effort by design. Every caller here is doing something else
+that matters more -- creating an account, creating an invite -- and a mail
+provider having a bad afternoon should not turn that into a 500. Failures are
+logged and reported through the return value; nothing in this module raises.
+"""
+
+import os
+import sys
+from html import escape
+
+import requests
+
+RESEND_API_URL = "https://api.resend.com/emails"
+
+# How long to wait on Resend. Callers run this in a background task, but a
+# hung connection would still pin a worker thread indefinitely without this.
+SEND_TIMEOUT_SECONDS = 10
+
+
+def _from_address() -> str:
+    return os.environ.get("RESEND_FROM", "Kanban <noreply@kanban.pearachute.com>")
+
+
+def public_base_url() -> str:
+    """Origin used to build links in outgoing mail.
+
+    Not derived from the incoming request: the links outlive the request, and
+    Host is attacker-controlled, so a forged Host would let someone send mail
+    from us pointing at their own server.
+    """
+    return os.environ.get("PUBLIC_BASE_URL", "https://kanban.pearachute.com").rstrip(
+        "/"
+    )
+
+
+def send_email(to: str, subject: str, html: str) -> bool:
+    """Send one email. Returns whether it was actually handed to Resend.
+
+    With no RESEND_API_KEY configured this prints the message to stderr and
+    returns False, which is what makes local development and the test suite
+    work without a key or network access -- verification links show up in the
+    server console instead of an inbox.
+    """
+    api_key = os.environ.get("RESEND_API_KEY", "").strip()
+    if not api_key:
+        print(
+            f"kanban: RESEND_API_KEY not set, not sending mail.\n"
+            f"kanban:   to: {to}\n"
+            f"kanban:   subject: {subject}\n"
+            f"kanban:   body:\n{html}",
+            file=sys.stderr,
+        )
+        return False
+
+    try:
+        response = requests.post(
+            RESEND_API_URL,
+            headers={
+                "Authorization": f"Bearer {api_key}",
+                "Content-Type": "application/json",
+            },
+            json={
+                "from": _from_address(),
+                "to": [to],
+                "subject": subject,
+                "html": html,
+            },
+            timeout=SEND_TIMEOUT_SECONDS,
+        )
+    except requests.RequestException as exc:
+        print(f"kanban: failed to send mail to {to}: {exc}", file=sys.stderr)
+        return False
+
+    if not response.ok:
+        # Resend puts the reason in the body; the status alone is rarely enough
+        # to tell "unverified sending domain" from "malformed address".
+        print(
+            f"kanban: Resend rejected mail to {to}: "
+            f"{response.status_code} {response.text}",
+            file=sys.stderr,
+        )
+        return False
+
+    return True
+
+
+def _button(url: str, label: str) -> str:
+    return (
+        f'<p><a href="{escape(url)}" '
+        'style="display:inline-block;padding:12px 20px;background:#2563eb;'
+        'color:#ffffff;border-radius:8px;text-decoration:none;'
+        f'font-weight:500">{escape(label)}</a></p>'
+        f'<p style="color:#6b7280;font-size:13px">Or paste this into your '
+        f'browser:<br>{escape(url)}</p>'
+    )
+
+
+def send_verification_email(user, token: str) -> bool:
+    """Email a new signup the link that activates their account."""
+    url = f"{public_base_url()}/verify?token={token}"
+    html = (
+        f"<p>Hi {escape(user.username)},</p>"
+        "<p>Confirm your email address to finish setting up your Kanban "
+        "account.</p>"
+        f"{_button(url, 'Verify email')}"
+        "<p style=\"color:#6b7280;font-size:13px\">This link expires in 24 "
+        "hours. If you didn't sign up, you can ignore this email.</p>"
+    )
+    return send_email(user.email, "Verify your Kanban email address", html)
+
+
+def send_invite_email(
+    to_email: str, invite_token: str, org_name: str, inviter_username: str
+) -> bool:
+    """Email someone the link to join an organization."""
+    url = f"{public_base_url()}/invite/{invite_token}"
+    html = (
+        f"<p><strong>{escape(inviter_username)}</strong> invited you to join "
+        f"<strong>{escape(org_name)}</strong> on Kanban.</p>"
+        f"{_button(url, 'Accept invitation')}"
+        "<p style=\"color:#6b7280;font-size:13px\">This invitation expires in "
+        "7 days.</p>"
+    )
+    return send_email(to_email, f"{inviter_username} invited you to {org_name}", html)

--- a/backend/migrations/001_unix_permissions.py
+++ b/backend/migrations/001_unix_permissions.py
@@ -1,92 +1,85 @@
+"""Peewee migrations -- 001_unix_permissions.
+
+Update the schema for Unix-like permissions:
+
+1. Add owner_id to Organization, populated from the old
+   organization_member.role == 'owner' rows
+2. Add is_public_to_org to Board (default False)
+3. Leave the now-orphaned role columns alone; the app ignores them
+
+Originally a standalone script run by hand. Converted to run under
+peewee-migrate so deploys apply it automatically -- see manage.py migrate.
+
+Written to be safely re-runnable. Production applied this by hand long before
+there was a migration history table, so the first router run will try it
+again; every step below checks before it acts. A fresh install is also a
+no-op, because init_db() creates these tables from the models with the
+columns already present.
 """
-Migration to update database schema for Unix-like permissions.
 
-Changes:
-1. Add owner_id column to Organization table
-2. Add is_public_to_org column to Board table (default False)
-3. Role columns in OrganizationMember and TeamMember will be ignored
-
-This migration is for SQLite which has limited ALTER TABLE support.
-
-Run from the project root: python backend/migrations/001_unix_permissions.py
-"""
-
-import sqlite3
-import os
+import peewee as pw
+from peewee_migrate import Migrator
 
 
-def migrate():
-    db_path = os.path.join(os.getcwd(), "kanban.db")
+def _table_exists(database, table):
+    rows = database.execute_sql(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name=?", (table,)
+    ).fetchall()
+    return bool(rows)
 
-    if not os.path.exists(db_path):
-        print("No database file found at:", db_path)
+
+def _columns(database, table):
+    return [row[1] for row in database.execute_sql(f"PRAGMA table_info({table})")]
+
+
+def migrate(migrator: Migrator, database: pw.Database, *, fake=False):
+    if fake:
         return
 
-    conn = sqlite3.connect(db_path)
-    cursor = conn.cursor()
+    for table in ("organization", "board"):
+        if not _table_exists(database, table):
+            print(f"  {table} table does not exist yet, nothing to migrate")
+            return
 
-    print("Starting migration...")
-
-    # Step 1: Check current schema
-    print("Step 1: Checking current schema...")
-    cursor.execute("PRAGMA table_info(organization)")
-    columns = [row[1] for row in cursor.fetchall()]
-    print(f"  Current organization columns: {columns}")
-
-    cursor.execute("PRAGMA table_info(board)")
-    columns = [row[1] for row in cursor.fetchall()]
-    print(f"  Current board columns: {columns}")
-
-    # Step 2: Back up existing organization owners (from organization_member.role = 'owner')
-    print("\nStep 2: Backing up organization ownership data...")
+    # Capture ownership from the old role column before adding owner_id. On a
+    # database that already migrated, the role column is gone and this yields
+    # nothing -- which is correct, owner_id is already populated.
+    org_owners = []
     try:
-        cursor.execute("""
+        org_owners = database.execute_sql("""
             SELECT om.organization_id, om.user_id, u.username, o.name
             FROM organization_member om
             JOIN user u ON om.user_id = u.id
             JOIN organization o ON om.organization_id = o.id
             WHERE om.role = 'owner'
-        """)
-        org_owners = cursor.fetchall()
+        """).fetchall()
         print(f"  Found {len(org_owners)} organization owners to migrate")
-        for org_id, user_id, username, org_name in org_owners:
-            print(f"    Org '{org_name}' (id={org_id}) -> owner: {username} (id={user_id})")
-    except sqlite3.OperationalError as e:
-        print(f"  Warning: Could not query organization members: {e}")
-        org_owners = []
+    except pw.OperationalError:
+        print("  No legacy role column to read ownership from, skipping")
 
-    # Step 3: Add owner_id column to organization table
-    print("\nStep 3: Adding owner_id column to organization table...")
-    try:
-        cursor.execute("ALTER TABLE organization ADD COLUMN owner_id INTEGER")
-        print("  Added owner_id column")
-    except sqlite3.OperationalError as e:
-        if "duplicate column name" in str(e):
-            print("  Column already exists, skipping...")
-        else:
-            print(f"  Error: {e}")
+    if "owner_id" in _columns(database, "organization"):
+        print("  organization.owner_id already exists")
+    else:
+        database.execute_sql("ALTER TABLE organization ADD COLUMN owner_id INTEGER")
+        print("  Added organization.owner_id")
 
-    # Step 4: Add is_public_to_org column to board table
-    print("\nStep 4: Adding is_public_to_org column to board table...")
-    try:
-        cursor.execute("ALTER TABLE board ADD COLUMN is_public_to_org INTEGER DEFAULT 0")
-        print("  Added is_public_to_org column")
-    except sqlite3.OperationalError as e:
-        if "duplicate column name" in str(e):
-            print("  Column already exists, skipping...")
-        else:
-            print(f"  Error: {e}")
+    if "is_public_to_org" in _columns(database, "board"):
+        print("  board.is_public_to_org already exists")
+    else:
+        database.execute_sql(
+            "ALTER TABLE board ADD COLUMN is_public_to_org INTEGER DEFAULT 0"
+        )
+        print("  Added board.is_public_to_org")
 
-    # Step 5: Update organization owner_id values
-    print("\nStep 5: Setting organization owners...")
     for org_id, user_id, username, org_name in org_owners:
-        cursor.execute("UPDATE organization SET owner_id = ? WHERE id = ?", (user_id, org_id))
-        print(f"  Set owner_id={user_id} for org id={org_id} ({org_name})")
+        database.execute_sql(
+            "UPDATE organization SET owner_id = ? WHERE id = ?", (user_id, org_id)
+        )
+        print(f"  Set owner_id={user_id} ({username}) on org {org_id} ({org_name})")
 
-    # Step 6: Handle organizations that might not have an owner set
-    print("\nStep 6: Setting fallback owners for any orgs without owner...")
+    # Any org still without an owner falls back to its lowest-id member.
     try:
-        cursor.execute("""
+        database.execute_sql("""
             UPDATE organization
             SET owner_id = (
                 SELECT MIN(user_id) FROM organization_member
@@ -95,23 +88,16 @@ def migrate():
             WHERE owner_id IS NULL
             AND id IN (SELECT DISTINCT organization_id FROM organization_member)
         """)
-        print(f"  Updated {cursor.rowcount} organizations with fallback owners")
-    except sqlite3.OperationalError:
-        print("  (organization_member table not found, skipping fallback owners)")
-
-    conn.commit()
-    conn.close()
-
-    print("\n" + "="*60)
-    print("Migration completed successfully!")
-    print("="*60)
-    print("\nNote: role columns in organization_member and team_member tables")
-    print("      are now orphaned and will be ignored by the application.")
-    print("\nThe new permission model:")
-    print("  - Organization has an explicit owner (like root)")
-    print("  - Board can be shared with one team or made public to org")
-    print("  - Any team member can add other org members to the team")
+        print("  Applied fallback owners where needed")
+    except pw.OperationalError:
+        print("  organization_member table not found, skipping fallback owners")
 
 
-if __name__ == "__main__":
-    migrate()
+def rollback(migrator: Migrator, database: pw.Database, *, fake=False):
+    """No rollback.
+
+    SQLite cannot drop a column without rebuilding the table, and the data
+    this migration recovered (ownership) has no home to go back to -- the
+    role column it came from is gone.
+    """
+    raise NotImplementedError("001_unix_permissions cannot be rolled back")

--- a/backend/migrations/002_email_verification.py
+++ b/backend/migrations/002_email_verification.py
@@ -1,0 +1,100 @@
+"""Peewee migrations -- 002_email_verification.
+
+Support self-serve signup with email verification:
+
+1. Add email_verified to User
+2. Mark every pre-existing user as verified
+3. Add a unique index on User.email
+
+Step 2 is the subtle one. The column defaults to 0 and login refuses
+unverified users, so without the backfill every account that predates this
+migration -- including any admin -- would be locked out. It is deliberately
+tied to having just created the column: on a re-run it must not re-verify
+accounts that have since signed up and genuinely not confirmed yet.
+
+The emailverificationtoken table is not created here. init_db() calls
+create_tables(), which adds missing tables on the next start.
+"""
+
+import peewee as pw
+from peewee_migrate import Migrator
+
+
+def _table_exists(database, table):
+    rows = database.execute_sql(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name=?", (table,)
+    ).fetchall()
+    return bool(rows)
+
+
+def _columns(database, table):
+    return [row[1] for row in database.execute_sql(f"PRAGMA table_info({table})")]
+
+
+def migrate(migrator: Migrator, database: pw.Database, *, fake=False):
+    if fake:
+        return
+
+    if not _table_exists(database, "user"):
+        print("  user table does not exist yet, nothing to migrate")
+        return
+
+    if "email_verified" in _columns(database, "user"):
+        # Either a fresh install, where create_tables() already built the
+        # column from the model, or a re-run. Either way the backfill below
+        # must not fire: a fresh database has no legacy accounts, and a re-run
+        # would wrongly verify real pending signups.
+        print("  user.email_verified already exists, skipping backfill")
+    else:
+        database.execute_sql(
+            "ALTER TABLE user ADD COLUMN email_verified INTEGER NOT NULL DEFAULT 0"
+        )
+        print("  Added user.email_verified")
+
+        cursor = database.execute_sql("UPDATE user SET email_verified = 1")
+        print(f"  Marked {cursor.rowcount} pre-existing users verified")
+
+    # Nothing stopped two accounts sharing an address until now. Which one
+    # keeps it is a human decision, so refuse rather than guess.
+    duplicates = database.execute_sql("""
+        SELECT email, COUNT(*) FROM user
+        WHERE email IS NOT NULL AND email != ''
+        GROUP BY email HAVING COUNT(*) > 1
+    """).fetchall()
+
+    if duplicates:
+        lines = []
+        for email, count in duplicates:
+            holders = database.execute_sql(
+                "SELECT id, username FROM user WHERE email = ?", (email,)
+            ).fetchall()
+            who = ", ".join(f"{name} (id={uid})" for uid, name in holders)
+            lines.append(f"    {email}: {count} accounts -> {who}")
+        raise RuntimeError(
+            "Cannot add a unique index on user.email -- duplicates exist:\n"
+            + "\n".join(lines)
+            + "\n  Clear or change the email on all but one account of each "
+            "set, then deploy again."
+        )
+
+    # Named user_email, not something of our own choosing, because that is
+    # what peewee generates for `email = CharField(unique=True)` when
+    # create_tables() builds a fresh database. Matching it means a migrated
+    # database and a fresh install converge on exactly one index with one
+    # name, instead of the fresh install carrying both and drifting.
+    #
+    # NULLs are exempt from a unique index in SQLite, so accounts with no
+    # email at all are unaffected.
+    database.execute_sql(
+        "CREATE UNIQUE INDEX IF NOT EXISTS user_email ON user(email)"
+    )
+    print("  Unique index user_email in place")
+
+
+def rollback(migrator: Migrator, database: pw.Database, *, fake=False):
+    """Drop the unique index.
+
+    The column itself stays: SQLite cannot drop one without rebuilding the
+    table, and leaving it costs nothing because older code never selects it.
+    """
+    database.execute_sql("DROP INDEX IF EXISTS user_email")

--- a/backend/models.py
+++ b/backend/models.py
@@ -21,14 +21,38 @@ class BaseModel(Model):
 PASSWORD_MAX_LENGTH = 72
 
 
+def _as_datetime(value):
+    """Normalize a DateTimeField read back into an aware UTC datetime.
+
+    Peewee writes aware datetimes to SQLite as '...+00:00', which matches none
+    of the formats it tries when reading them back, so it hands us the raw
+    string instead. Naive values are assumed UTC -- everything in this file
+    writes UTC, and a naive value would otherwise blow up on comparison with
+    an aware one.
+    """
+    if isinstance(value, str):
+        value = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return value
+
+
 class User(BaseModel):
     username = CharField(unique=True, max_length=100)
     password_hash = CharField(max_length=255)
-    email = CharField(max_length=255, null=True)
+    # Unique, but still nullable: accounts predating self-serve signup have no
+    # email, and SQLite lets a unique index hold any number of NULLs.
+    email = CharField(max_length=255, null=True, unique=True)
+    # Self-serve signups start False and are gated out of login until they
+    # click the emailed link. Accounts made by an admin or the CLI are created
+    # verified -- whoever ran that already vouched for the person.
+    email_verified = BooleanField(default=False)
     admin = BooleanField(default=False)
 
     @classmethod
-    def create_user(cls, username, password, email=None, admin=False):
+    def create_user(
+        cls, username, password, email=None, admin=False, email_verified=True
+    ):
         if len(password) > PASSWORD_MAX_LENGTH:
             raise ValueError(
                 f"Password must be {PASSWORD_MAX_LENGTH} characters or fewer"
@@ -37,7 +61,11 @@ class User(BaseModel):
             password.encode("utf-8"), bcrypt.gensalt()
         ).decode("utf-8")
         return cls.create(
-            username=username, password_hash=password_hash, email=email, admin=admin
+            username=username,
+            password_hash=password_hash,
+            email=email,
+            admin=admin,
+            email_verified=email_verified,
         )
 
     def verify_password(self, password):
@@ -255,10 +283,7 @@ class OrganizationInvite(BaseModel):
 
     def is_expired(self):
         """Check if invite has expired."""
-        expires_at = self.expires_at
-        if isinstance(expires_at, str):
-            expires_at = datetime.fromisoformat(expires_at.replace("Z", "+00:00"))
-        return datetime.now(timezone.utc) > expires_at
+        return datetime.now(timezone.utc) > _as_datetime(self.expires_at)
 
     def revoke(self):
         """Revoke this invite."""
@@ -283,3 +308,63 @@ class OrganizationInvite(BaseModel):
             organization=self.organization,
             joined_at=datetime.now(timezone.utc),
         )
+
+
+VERIFICATION_TOKEN_EXPIRY_HOURS = 24
+
+
+class EmailVerificationToken(BaseModel):
+    """One-shot token proving a self-serve signup owns their email address."""
+
+    user = ForeignKeyField(User, backref="verification_tokens")
+    token = CharField(max_length=64, unique=True)
+    created_at = DateTimeField()
+    expires_at = DateTimeField()
+    used_at = DateTimeField(null=True)
+
+    @classmethod
+    def create_for(cls, user):
+        """Issue a fresh token for a user. Returns (record, token)."""
+        token = generate_invite_token()
+        now = datetime.now(timezone.utc)
+        return cls.create(
+            user=user,
+            token=token,
+            created_at=now,
+            expires_at=now + timedelta(hours=VERIFICATION_TOKEN_EXPIRY_HOURS),
+        ), token
+
+    def is_expired(self):
+        expires_at = _as_datetime(self.expires_at)
+        return datetime.now(timezone.utc) > expires_at
+
+    def is_used(self):
+        return self.used_at is not None
+
+    def mark_used(self):
+        self.used_at = datetime.now(timezone.utc)
+        self.save()
+
+
+# Every model, parents before children.
+#
+# Single source of truth: database.py, manage.py and the test fixtures all read
+# this instead of keeping their own copies. They used to keep four separate
+# lists, and manage.py's drifted three tables out of date -- `manage.py init`
+# quietly built an incomplete schema and `manage.py status` under-reported.
+# Adding a model here is now the only step required.
+ALL_MODELS = [
+    User,
+    Board,
+    Column,
+    Card,
+    Comment,
+    Organization,
+    OrganizationMember,
+    Team,
+    TeamMember,
+    BetaSignup,
+    ApiKey,
+    OrganizationInvite,
+    EmailVerificationToken,
+]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,6 +1,7 @@
 fastapi
 uvicorn
 peewee
+peewee-migrate
 pydantic
 python-jose[cryptography]
 bcrypt

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -460,20 +460,28 @@ def test_create_column_without_position_appends(client, auth_headers, test_user)
         "/api/boards", json={"name": "Append Board"}, headers=auth_headers
     ).json()["id"]
 
+    # A new board is not empty -- it comes with the default columns. Derived
+    # rather than hardcoded so changing that default list does not break this
+    # test, which is about appending, not about what the defaults are.
+    existing = client.get(f"/api/boards/{board_id}", headers=auth_headers).json()[
+        "columns"
+    ]
+    end = max(c["position"] for c in existing) + 1
+
     first = client.post(
         "/api/columns",
         json={"board_id": board_id, "name": "First"},
         headers=auth_headers,
     )
     assert first.status_code == 200
-    assert first.json()["position"] == 0
+    assert first.json()["position"] == end
 
     second = client.post(
         "/api/columns",
         json={"board_id": board_id, "name": "Second"},
         headers=auth_headers,
     )
-    assert second.json()["position"] == 1
+    assert second.json()["position"] == end + 1
 
 
 def test_create_column_appends_after_the_highest_position(

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -116,13 +116,13 @@ def test_get_board_with_columns(client, auth_headers, test_user):
     assert response.status_code == 200
     board_id = response.json()["id"]
 
-    # Get board - columns need to be created separately since API doesn't create defaults
     response = client.get(f"/api/boards/{board_id}", headers=auth_headers)
     assert response.status_code == 200
     data = response.json()
     assert data["name"] == "Board with Columns"
     assert "columns" in data
-    # Note: API no longer creates default columns
+    assert len(data["columns"]) == 3
+    assert data["columns"][0]["name"] == "To Do"
 
 
 def test_create_column(client, auth_headers, test_user):
@@ -270,7 +270,7 @@ def test_delete_board(client, auth_headers, test_user):
 
 def test_reorder_cards(client, auth_headers, test_user):
     """Test reordering cards within a column"""
-    # Create board and column
+    # Create board (gets default columns: To Do, In Progress, For Review)
     response = client.post(
         "/api/boards",
         json={"name": "Reorder Cards Board"},
@@ -278,12 +278,12 @@ def test_reorder_cards(client, auth_headers, test_user):
     )
     board_id = response.json()["id"]
 
-    response = client.post(
-        "/api/columns",
-        json={"board_id": board_id, "name": "To Do", "position": 0},
+    # Use the first default column
+    response = client.get(
+        f"/api/boards/{board_id}",
         headers=auth_headers,
     )
-    column_id = response.json()["id"]
+    column_id = response.json()["columns"][0]["id"]
 
     # Create multiple cards
     card_ids = []
@@ -320,7 +320,7 @@ def test_reorder_cards(client, auth_headers, test_user):
 
 def test_reorder_columns(client, auth_headers, test_user):
     """Test reordering columns on a board"""
-    # Create board
+    # Create board (gets default columns: To Do, In Progress, For Review)
     response = client.post(
         "/api/boards",
         json={"name": "Reorder Columns Board"},
@@ -328,15 +328,13 @@ def test_reorder_columns(client, auth_headers, test_user):
     )
     board_id = response.json()["id"]
 
-    # Create multiple columns
-    column_ids = []
-    for i in range(3):
-        response = client.post(
-            "/api/columns",
-            json={"board_id": board_id, "name": f"Column {i}", "position": i},
-            headers=auth_headers,
-        )
-        column_ids.append(response.json()["id"])
+    # Fetch the default columns
+    response = client.get(
+        f"/api/boards/{board_id}",
+        headers=auth_headers,
+    )
+    columns = response.json()["columns"]
+    column_ids = [c["id"] for c in columns]
 
     # Reorder columns: reverse their order
     reorder_request = [
@@ -357,7 +355,7 @@ def test_reorder_columns(client, auth_headers, test_user):
     response = client.get(f"/api/boards/{board_id}", headers=auth_headers)
     assert response.status_code == 200
     column_names = [c["name"] for c in response.json()["columns"]]
-    assert column_names == ["Column 2", "Column 1", "Column 0"]
+    assert column_names == ["For Review", "In Progress", "To Do"]
 
 
 def test_reorder_cards_requires_auth(client):

--- a/backend/tests/test_routes.py
+++ b/backend/tests/test_routes.py
@@ -75,3 +75,79 @@ def test_api_routes_still_work(client, test_user):
     response = client.get("/api/boards", headers=headers)
     assert response.status_code == 200
     assert isinstance(response.json(), list)
+
+
+def test_health_endpoint_reports_ok(client, db_session):
+    """The deploy pipeline gates on this response body."""
+    response = client.get("/api/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
+def test_health_endpoint_is_public(client, db_session):
+    """No auth: the deploy check has no credentials."""
+    response = client.get("/api/health", headers={})
+    assert response.status_code == 200
+
+
+def test_health_is_a_real_route_not_the_spa_fallback(client, db_session):
+    """Regression guard for the check that could never fail.
+
+    An undefined /api/... path falls through to the SPA catch-all in main.py
+    and returns 200 with index.html. The deploy used to curl /api/health --
+    which did not exist -- and accept that as healthy. If this route is ever
+    removed, this test fails instead of the deploy silently going green.
+    """
+    response = client.get("/api/health")
+    assert "text/html" not in response.headers["content-type"]
+    assert response.headers["content-type"].startswith("application/json")
+
+
+def test_health_reports_503_when_the_database_is_broken(client, db_session, monkeypatch):
+    """A schema or connection failure must surface, not be swallowed.
+
+    This is the case the old check missed entirely: an unmigrated database
+    500s every real request while static files keep serving fine.
+    """
+    from backend.models import User
+
+    def boom(*args, **kwargs):
+        raise Exception("no such column: t1.email_verified")
+
+    monkeypatch.setattr(User, "select", boom)
+
+    response = client.get("/api/health")
+    assert response.status_code == 503
+    assert "Database unavailable" in response.json()["detail"]
+
+
+def test_health_query_names_every_user_column(client, db_session, monkeypatch):
+    """The health query must select real columns, not just count rows.
+
+    Regression guard with history: this endpoint originally used
+    User.select().limit(1).count(), which peewee compiles to
+    SELECT COUNT(1) FROM (SELECT 1 FROM user LIMIT 1). That names no model
+    columns, so it returned 200 against an unmigrated copy of production
+    while /api/token was dying on "no such column: t1.email_verified" --
+    the endpoint reproduced the exact blind spot it exists to close.
+
+    Simulated by failing any statement that mentions the newest column. A
+    query that does not reference it never trips this and the assertion below
+    fails, which is the point.
+    """
+    from backend.database import db
+
+    original = db.execute_sql
+
+    def fail_on_new_column(sql, *args, **kwargs):
+        if "email_verified" in str(sql):
+            raise Exception("no such column: t1.email_verified")
+        return original(sql, *args, **kwargs)
+
+    monkeypatch.setattr(db, "execute_sql", fail_on_new_column)
+
+    response = client.get("/api/health")
+    assert response.status_code == 503, (
+        "health passed without ever selecting email_verified -- it would not "
+        "notice an unmigrated database"
+    )

--- a/backend/tests/test_routes.py
+++ b/backend/tests/test_routes.py
@@ -90,17 +90,20 @@ def test_health_endpoint_is_public(client, db_session):
     assert response.status_code == 200
 
 
-def test_health_is_a_real_route_not_the_spa_fallback(client, db_session):
+def test_health_is_a_real_route(client, db_session):
     """Regression guard for the check that could never fail.
 
-    An undefined /api/... path falls through to the SPA catch-all in main.py
-    and returns 200 with index.html. The deploy used to curl /api/health --
-    which did not exist -- and accept that as healthy. If this route is ever
-    removed, this test fails instead of the deploy silently going green.
+    The deploy curled /api/health for a long time before the route existed.
+    Unmatched /api/ paths answered 200 with the SPA's index.html back then, so
+    the check passed on nothing at all; main.py 404s them now, but the deploy
+    also accepted 404, so it still passed on nothing. Either way a missing
+    route read as healthy. If this one is ever removed, fail here rather than
+    let a deploy go green over it.
     """
     response = client.get("/api/health")
-    assert "text/html" not in response.headers["content-type"]
+    assert response.status_code == 200
     assert response.headers["content-type"].startswith("application/json")
+    assert response.json() == {"status": "ok"}
 
 
 def test_health_reports_503_when_the_database_is_broken(client, db_session, monkeypatch):

--- a/backend/tests/test_signup.py
+++ b/backend/tests/test_signup.py
@@ -1,0 +1,318 @@
+"""Tests for self-serve signup and email verification."""
+
+import os
+import sys
+import random
+import string
+import pytest
+from datetime import datetime, timedelta, timezone
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from backend.main import app
+from backend.models import (
+    User,
+    Organization,
+    OrganizationMember,
+    EmailVerificationToken,
+)
+from backend.auth import create_access_token
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+@pytest.fixture
+def sent(monkeypatch):
+    """Capture outgoing mail instead of sending it.
+
+    Patches send_email, the single choke point every helper in backend.mailer
+    funnels through, so the helpers' own link-building still runs and is
+    covered here.
+    """
+    captured = []
+
+    def fake_send_email(to, subject, html):
+        captured.append({"to": to, "subject": subject, "html": html})
+        return True
+
+    monkeypatch.setattr("backend.mailer.send_email", fake_send_email)
+    return captured
+
+
+def unique(base):
+    suffix = "".join(random.choices(string.ascii_lowercase + string.digits, k=8))
+    return f"{base}-{suffix}"
+
+
+def signup(client, username=None, email=None, password="hunter2hunter2"):
+    username = username or unique("newuser").replace("-", "_")
+    email = email or f"{unique('someone')}@example.com"
+    return client.post(
+        "/api/signup",
+        json={"username": username, "email": email, "password": password},
+    ), username, email
+
+
+class TestSignup:
+    """POST /api/signup"""
+
+    def test_creates_unverified_user_and_sends_one_email(
+        self, client, sent, db_session
+    ):
+        response, username, email = signup(client)
+
+        assert response.status_code == 201
+        assert response.json()["email"] == email
+
+        user = User.get_or_none(User.username == username)
+        assert user is not None
+        assert user.email == email
+        assert user.email_verified is False
+
+        assert len(sent) == 1
+        assert sent[0]["to"] == email
+        # The link the user has to click must actually be in the body.
+        token = EmailVerificationToken.get(EmailVerificationToken.user == user).token
+        assert f"/verify?token={token}" in sent[0]["html"]
+
+    def test_email_is_normalized_to_lowercase(self, client, sent, db_session):
+        response, username, _ = signup(client, email="MiXeD@Example.COM")
+        assert response.status_code == 201
+        assert User.get(User.username == username).email == "mixed@example.com"
+
+    def test_duplicate_username_rejected(self, client, sent, db_session):
+        _, username, _ = signup(client)
+        response, _, _ = signup(client, username=username)
+        assert response.status_code == 400
+        assert "username" in response.json()["detail"].lower()
+
+    def test_duplicate_email_rejected(self, client, sent, db_session):
+        _, _, email = signup(client)
+        response, _, _ = signup(client, email=email)
+        assert response.status_code == 400
+        assert "email" in response.json()["detail"].lower()
+
+    def test_invalid_email_rejected(self, client, sent, db_session):
+        response, _, _ = signup(client, email="not-an-email")
+        assert response.status_code == 400
+        assert sent == []
+
+    def test_overlong_password_rejected(self, client, sent, db_session):
+        response, username, _ = signup(client, password="x" * 100)
+        assert response.status_code == 400
+        assert User.get_or_none(User.username == username) is None
+
+    def test_failed_signup_creates_nothing(self, client, sent, db_session):
+        """A rejected signup must not leave a half-made account behind."""
+        before = User.select().count()
+        signup(client, email="bad")
+        assert User.select().count() == before
+
+
+class TestVerificationGate:
+    """Unverified accounts cannot log in."""
+
+    def test_login_refused_until_verified_then_allowed(
+        self, client, sent, db_session
+    ):
+        _, username, _ = signup(client)
+
+        response = client.post(
+            "/api/token", json={"username": username, "password": "hunter2hunter2"}
+        )
+        assert response.status_code == 403
+        assert response.json()["detail"] == "Email not verified"
+
+        user = User.get(User.username == username)
+        token = EmailVerificationToken.get(EmailVerificationToken.user == user).token
+        assert client.post("/api/verify-email", json={"token": token}).status_code == 200
+
+        response = client.post(
+            "/api/token", json={"username": username, "password": "hunter2hunter2"}
+        )
+        assert response.status_code == 200
+        assert "access_token" in response.json()
+
+    def test_wrong_password_still_401_not_403(self, client, sent, db_session):
+        """Verification state must not leak to someone guessing passwords."""
+        _, username, _ = signup(client)
+        response = client.post(
+            "/api/token", json={"username": username, "password": "wrong"}
+        )
+        assert response.status_code == 401
+
+    def test_admin_created_users_are_verified(self, client, db_session):
+        """manage.py and the admin endpoint must not make unusable accounts."""
+        user = User.create_user(unique("admin").replace("-", "_"), "password123")
+        assert user.email_verified is True
+
+
+class TestVerifyEmail:
+    """POST /api/verify-email"""
+
+    def _token_for(self, client, sent, db_session):
+        _, username, _ = signup(client)
+        user = User.get(User.username == username)
+        return user, EmailVerificationToken.get(EmailVerificationToken.user == user)
+
+    def test_returns_a_working_access_token(self, client, sent, db_session):
+        user, record = self._token_for(client, sent, db_session)
+
+        response = client.post("/api/verify-email", json={"token": record.token})
+        assert response.status_code == 200
+
+        access_token = response.json()["access_token"]
+        me = client.get(
+            "/api/boards", headers={"Authorization": f"Bearer {access_token}"}
+        )
+        assert me.status_code == 200
+
+    def test_token_is_single_use(self, client, sent, db_session):
+        _, record = self._token_for(client, sent, db_session)
+
+        assert client.post(
+            "/api/verify-email", json={"token": record.token}
+        ).status_code == 200
+        response = client.post("/api/verify-email", json={"token": record.token})
+        assert response.status_code == 400
+        assert "already been used" in response.json()["detail"]
+
+    def test_expired_token_rejected(self, client, sent, db_session):
+        user, record = self._token_for(client, sent, db_session)
+
+        record.expires_at = datetime.now(timezone.utc) - timedelta(hours=1)
+        record.save()
+
+        response = client.post("/api/verify-email", json={"token": record.token})
+        assert response.status_code == 400
+        assert "expired" in response.json()["detail"].lower()
+        assert User.get(User.id == user.id).email_verified is False
+
+    def test_unknown_token_rejected(self, client, db_session):
+        response = client.post("/api/verify-email", json={"token": "nope"})
+        assert response.status_code == 404
+
+
+class TestResendVerification:
+    """POST /api/resend-verification"""
+
+    def test_cooldown_blocks_a_rapid_second_request(self, client, sent, db_session):
+        _, _, email = signup(client)
+        response = client.post("/api/resend-verification", json={"email": email})
+        assert response.status_code == 429
+        assert len(sent) == 1  # only the original signup mail
+
+    def test_sends_once_cooldown_has_passed(self, client, sent, db_session):
+        _, username, email = signup(client)
+        user = User.get(User.username == username)
+
+        record = EmailVerificationToken.get(EmailVerificationToken.user == user)
+        record.created_at = datetime.now(timezone.utc) - timedelta(minutes=5)
+        record.save()
+
+        response = client.post("/api/resend-verification", json={"email": email})
+        assert response.status_code == 200
+        assert len(sent) == 2
+
+    def test_unknown_email_matches_known_email_response(
+        self, client, sent, db_session
+    ):
+        """No account enumeration: both cases return the same body."""
+        _, username, email = signup(client)
+        user = User.get(User.username == username)
+        record = EmailVerificationToken.get(EmailVerificationToken.user == user)
+        record.created_at = datetime.now(timezone.utc) - timedelta(minutes=5)
+        record.save()
+
+        known = client.post("/api/resend-verification", json={"email": email})
+        unknown = client.post(
+            "/api/resend-verification", json={"email": "nobody@example.com"}
+        )
+
+        assert known.status_code == unknown.status_code == 200
+        assert known.json() == unknown.json()
+
+    def test_already_verified_sends_nothing(self, client, sent, db_session):
+        _, username, email = signup(client)
+        user = User.get(User.username == username)
+        user.email_verified = True
+        user.save()
+
+        response = client.post("/api/resend-verification", json={"email": email})
+        assert response.status_code == 200
+        assert len(sent) == 1  # signup mail only
+
+
+class TestInviteEmail:
+    """Org invites are actually delivered now."""
+
+    def test_invite_with_email_is_sent(self, client, sent, test_user, db_session):
+        org = Organization.create_with_columns("Acme", unique("acme"), test_user)
+        headers = {
+            "Authorization": f"Bearer {create_access_token(data={'sub': test_user.id, 'username': test_user.username})}"
+        }
+
+        response = client.post(
+            f"/api/organizations/{org.id}/invites",
+            json={"email": "invitee@example.com"},
+            headers=headers,
+        )
+        assert response.status_code == 200
+
+        assert len(sent) == 1
+        assert sent[0]["to"] == "invitee@example.com"
+        assert f"/invite/{response.json()['token']}" in sent[0]["html"]
+        assert "Acme" in sent[0]["html"]
+
+    def test_anonymous_invite_sends_nothing(self, client, sent, test_user, db_session):
+        org = Organization.create_with_columns("Acme", unique("acme"), test_user)
+        headers = {
+            "Authorization": f"Bearer {create_access_token(data={'sub': test_user.id, 'username': test_user.username})}"
+        }
+
+        response = client.post(
+            f"/api/organizations/{org.id}/invites", json={}, headers=headers
+        )
+        assert response.status_code == 200
+        assert sent == []
+
+
+class TestSignupGrantsNoOrgAccess:
+    """A self-serve account must not land inside anyone else's organization."""
+
+    def _verified_signup(self, client):
+        _, username, _ = signup(client)
+        user = User.get(User.username == username)
+        record = EmailVerificationToken.get(EmailVerificationToken.user == user)
+        response = client.post("/api/verify-email", json={"token": record.token})
+        return user, {"Authorization": f"Bearer {response.json()['access_token']}"}
+
+    def test_new_account_has_no_organizations(self, client, sent, db_session):
+        _, headers = self._verified_signup(client)
+        response = client.get("/api/organizations", headers=headers)
+        assert response.status_code == 200
+        assert response.json() == []
+
+    def test_cannot_add_self_to_someone_elses_org(
+        self, client, sent, test_user, db_session
+    ):
+        org = Organization.create_with_columns("Private Co", unique("private"), test_user)
+        newcomer, headers = self._verified_signup(client)
+
+        response = client.post(
+            f"/api/organizations/{org.id}/members",
+            json={"username": newcomer.username},
+            headers=headers,
+        )
+        assert response.status_code == 403
+        assert (
+            OrganizationMember.get_or_none(
+                (OrganizationMember.organization == org)
+                & (OrganizationMember.user == newcomer)
+            )
+            is None
+        )

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -23,6 +23,8 @@
   import SettingsApiKeys from './routes/SettingsApiKeys.svelte';
   import ApiKeyCreated from './routes/ApiKeyCreated.svelte';
   import Invite from './routes/Invite.svelte';
+  import Signup from './routes/Signup.svelte';
+  import VerifyEmail from './routes/VerifyEmail.svelte';
 
   onMount(() => {
     theme.init();
@@ -59,6 +61,18 @@
   <Route path="/login" let:params>
     <PublicLayout>
       <Login {params} />
+    </PublicLayout>
+  </Route>
+
+  <Route path="/signup" let:params>
+    <PublicLayout>
+      <Signup {params} />
+    </PublicLayout>
+  </Route>
+
+  <Route path="/verify" let:params>
+    <PublicLayout>
+      <VerifyEmail {params} />
     </PublicLayout>
   </Route>
 

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -256,4 +256,20 @@ export const api = {
     get: (token) => apiFetch(`/api/invites/${token}`),
     accept: (token) => apiFetch(`/api/invites/${token}/accept`, { method: 'POST' }),
   },
+  auth: {
+    // All unauthenticated. apiFetch only force-logs-out on a 401 when a token
+    // was actually sent, so these surface their errors normally.
+    signup: (username, email, password) => apiFetch('/api/signup', {
+      method: 'POST',
+      body: JSON.stringify({ username, email, password }),
+    }),
+    verifyEmail: (token) => apiFetch('/api/verify-email', {
+      method: 'POST',
+      body: JSON.stringify({ token }),
+    }),
+    resendVerification: (email) => apiFetch('/api/resend-verification', {
+      method: 'POST',
+      body: JSON.stringify({ email }),
+    }),
+  },
 };

--- a/frontend/src/routes/Login.svelte
+++ b/frontend/src/routes/Login.svelte
@@ -2,9 +2,18 @@
   import { onMount } from 'svelte';
   import { navigate } from 'svelte-routing';
   import BetaSection from '../components/BetaSection.svelte';
+  import { api } from '../lib/api.js';
+
+  // Must match UNVERIFIED_EMAIL_DETAIL in backend/api.py.
+  const UNVERIFIED_DETAIL = 'Email not verified';
 
   let username = $state('');
   let password = $state('');
+  let error = $state(null);
+  let unverified = $state(false);
+  let resendEmail = $state('');
+  let resendNote = $state(null);
+  let resending = $state(false);
 
   onMount(() => {
     const token = localStorage.getItem('token');
@@ -16,6 +25,9 @@
   });
 
   async function login() {
+    error = null;
+    unverified = false;
+    resendNote = null;
     try {
       const res = await fetch('/api/token', {
         method: 'POST',
@@ -29,11 +41,33 @@
         const redirectPath = localStorage.getItem('redirectPath') || '/boards';
         localStorage.removeItem('redirectPath');
         navigate(redirectPath);
+        return;
+      }
+      // The body distinguishes "wrong password" from "correct password, but
+      // you never clicked the verification link" -- the second is recoverable
+      // and deserves a resend button rather than a dead end.
+      const body = await res.json().catch(() => ({}));
+      if (res.status === 403 && body.detail === UNVERIFIED_DETAIL) {
+        unverified = true;
+        error = 'Verify your email address before logging in.';
       } else {
-        alert('Login failed');
+        error = body.detail || 'Login failed';
       }
     } catch (e) {
-      alert('Login failed: ' + e.message);
+      error = 'Login failed: ' + e.message;
+    }
+  }
+
+  async function resend() {
+    resending = true;
+    resendNote = null;
+    try {
+      const result = await api.auth.resendVerification(resendEmail);
+      resendNote = result.message;
+    } catch (e) {
+      resendNote = e.message;
+    } finally {
+      resending = false;
     }
   }
 </script>
@@ -42,10 +76,30 @@
   <div class="login">
     <h1>Kanban Board</h1>
     <form onsubmit={(e) => { e.preventDefault(); login(); }}>
-      <input bind:value={username} placeholder="Username" required />
-      <input type="password" bind:value={password} placeholder="Password" required />
+      <input bind:value={username} placeholder="Username" required autocomplete="username" />
+      <input type="password" bind:value={password} placeholder="Password" required autocomplete="current-password" />
+      {#if error}
+        <p class="error">{error}</p>
+      {/if}
       <button type="submit">Login</button>
     </form>
+
+    {#if unverified}
+      <!-- Asks for the address rather than showing it: the server will not
+           tell an unauthenticated caller which email an account uses. -->
+      <div class="resend">
+        <p class="hint">Enter your email and we'll send a new verification link.</p>
+        <input type="email" bind:value={resendEmail} placeholder="Email" autocomplete="email" />
+        <button class="secondary" onclick={resend} disabled={resending || !resendEmail}>
+          {resending ? 'Sending...' : 'Resend verification email'}
+        </button>
+        {#if resendNote}
+          <p class="hint">{resendNote}</p>
+        {/if}
+      </div>
+    {/if}
+
+    <p class="alt">Need an account? <a href="/signup">Sign up</a></p>
 
     <BetaSection
       marginTop="2rem"
@@ -133,5 +187,56 @@
 
   .login button[type="submit"]:hover {
     opacity: 0.9;
+  }
+
+  .error {
+    color: var(--color-destructive);
+    font-size: 0.875rem;
+    margin: 0;
+  }
+
+  .resend {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    width: 100%;
+    max-width: 320px;
+    text-align: center;
+  }
+
+  .resend button.secondary {
+    background: transparent;
+    color: var(--color-foreground);
+    border: 1px solid var(--color-border);
+  }
+
+  .resend button.secondary:hover:not(:disabled) {
+    background: var(--color-accent);
+  }
+
+  .resend button.secondary:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+
+  .hint {
+    color: var(--color-muted);
+    font-size: 0.8125rem;
+    margin: 0;
+  }
+
+  .alt {
+    color: var(--color-muted);
+    font-size: 0.875rem;
+    margin: 0;
+  }
+
+  .alt a {
+    color: var(--color-primary);
+    text-decoration: none;
+  }
+
+  .alt a:hover {
+    text-decoration: underline;
   }
 </style>

--- a/frontend/src/routes/Signup.svelte
+++ b/frontend/src/routes/Signup.svelte
@@ -1,0 +1,201 @@
+<script>
+  import { onMount } from 'svelte';
+  import { navigate } from 'svelte-routing';
+  import { api } from '../lib/api.js';
+
+  let username = $state('');
+  let email = $state('');
+  let password = $state('');
+  let submitting = $state(false);
+  let error = $state(null);
+  let sentTo = $state(null);
+  let resending = $state(false);
+  let resendNote = $state(null);
+
+  onMount(() => {
+    // Already signed in -- nothing to sign up for.
+    if (localStorage.getItem('token')) {
+      const redirectPath = localStorage.getItem('redirectPath') || '/boards';
+      localStorage.removeItem('redirectPath');
+      navigate(redirectPath);
+    }
+  });
+
+  async function signup() {
+    submitting = true;
+    error = null;
+    try {
+      const result = await api.auth.signup(username, email, password);
+      sentTo = result.email;
+    } catch (e) {
+      error = e.message;
+    } finally {
+      submitting = false;
+    }
+  }
+
+  async function resend() {
+    resending = true;
+    resendNote = null;
+    try {
+      const result = await api.auth.resendVerification(sentTo);
+      resendNote = result.message;
+    } catch (e) {
+      resendNote = e.message;
+    } finally {
+      resending = false;
+    }
+  }
+</script>
+
+<div class="signup-container">
+  <div class="signup">
+    {#if sentTo}
+      <h1>Check your email</h1>
+      <p class="sent">
+        We sent a verification link to <strong>{sentTo}</strong>.
+        Click it to finish setting up your account.
+      </p>
+      <p class="hint">The link expires in 24 hours.</p>
+      <button class="secondary" onclick={resend} disabled={resending}>
+        {resending ? 'Sending...' : 'Resend the email'}
+      </button>
+      {#if resendNote}
+        <p class="hint">{resendNote}</p>
+      {/if}
+    {:else}
+      <h1>Create your account</h1>
+      <form onsubmit={(e) => { e.preventDefault(); signup(); }}>
+        <input bind:value={username} placeholder="Username" required autocomplete="username" />
+        <input bind:value={email} type="email" placeholder="Email" required autocomplete="email" />
+        <input bind:value={password} type="password" placeholder="Password" required autocomplete="new-password" />
+        {#if error}
+          <p class="error">{error}</p>
+        {/if}
+        <button type="submit" disabled={submitting}>
+          {submitting ? 'Creating account...' : 'Sign up'}
+        </button>
+      </form>
+      <p class="alt">Already have an account? <a href="/login">Log in</a></p>
+    {/if}
+  </div>
+</div>
+
+<style>
+  .signup-container {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 2rem 1rem;
+  }
+
+  .signup {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 1rem;
+    width: 100%;
+    max-width: 400px;
+    text-align: center;
+  }
+
+  .signup h1 {
+    font-size: 1.875rem;
+    font-weight: 700;
+    color: var(--color-primary);
+  }
+
+  .signup form {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    width: 100%;
+    max-width: 320px;
+  }
+
+  input {
+    padding: 0.75rem 1rem;
+    font-size: 1rem;
+    border-radius: 8px;
+    border: 1px solid var(--color-border);
+    background: var(--color-card);
+    color: var(--color-foreground);
+    transition: border-color 0.15s ease;
+  }
+
+  input:focus {
+    outline: none;
+    border-color: var(--color-primary);
+    box-shadow: 0 0 0 3px var(--color-primary);
+  }
+
+  button {
+    padding: 0.75rem 1rem;
+    font-size: 1rem;
+    font-weight: 500;
+    border-radius: 8px;
+    cursor: pointer;
+    transition: all 0.15s ease;
+    border: none;
+  }
+
+  .signup button[type="submit"] {
+    background: var(--color-primary);
+    color: var(--color-primary-foreground);
+  }
+
+  .signup button[type="submit"]:hover:not(:disabled) {
+    opacity: 0.9;
+  }
+
+  button:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+
+  button.secondary {
+    background: transparent;
+    color: var(--color-foreground);
+    border: 1px solid var(--color-border);
+  }
+
+  button.secondary:hover:not(:disabled) {
+    background: var(--color-accent);
+  }
+
+  .error {
+    color: var(--color-destructive);
+    font-size: 0.875rem;
+    margin: 0;
+    text-align: left;
+  }
+
+  .sent {
+    color: var(--color-foreground);
+    line-height: 1.6;
+    margin: 0;
+  }
+
+  .hint {
+    color: var(--color-muted);
+    font-size: 0.8125rem;
+    margin: 0;
+  }
+
+  .alt {
+    color: var(--color-muted);
+    font-size: 0.875rem;
+    margin: 0;
+  }
+
+  .alt a {
+    color: var(--color-primary);
+    text-decoration: none;
+  }
+
+  .alt a:hover {
+    text-decoration: underline;
+  }
+</style>

--- a/frontend/src/routes/VerifyEmail.svelte
+++ b/frontend/src/routes/VerifyEmail.svelte
@@ -1,0 +1,116 @@
+<script>
+  import { onMount } from 'svelte';
+  import { navigate } from 'svelte-routing';
+  import { api } from '../lib/api.js';
+
+  let status = $state('working'); // working | done | failed
+  let error = $state(null);
+
+  onMount(async () => {
+    const token = new URLSearchParams(window.location.search).get('token');
+    if (!token) {
+      status = 'failed';
+      error = 'This link is missing its verification token.';
+      return;
+    }
+
+    try {
+      const result = await api.auth.verifyEmail(token);
+      // Verifying logs you in, same as a successful login would.
+      localStorage.setItem('token', result.access_token);
+      status = 'done';
+
+      // Honour the redirect an invite link stashed before sending the user
+      // off to sign up, so invite -> signup -> verify lands back on the invite.
+      const redirectPath = localStorage.getItem('redirectPath') || '/boards';
+      localStorage.removeItem('redirectPath');
+      navigate(redirectPath);
+    } catch (e) {
+      status = 'failed';
+      error = e.message;
+    }
+  });
+</script>
+
+<div class="verify-container">
+  <div class="verify-card">
+    {#if status === 'working'}
+      <p class="loading">Verifying your email...</p>
+    {:else if status === 'done'}
+      <h1>You're verified</h1>
+      <p>Taking you to your boards...</p>
+    {:else}
+      <h1 class="failed">Verification failed</h1>
+      <p class="error">{error}</p>
+      <p class="hint">
+        Links expire after 24 hours and can only be used once.
+        You can request a new one from the login page.
+      </p>
+      <a href="/login" class="back-link">Go to login</a>
+    {/if}
+  </div>
+</div>
+
+<style>
+  .verify-container {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 2rem 1rem;
+  }
+
+  .verify-card {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1rem;
+    width: 100%;
+    max-width: 400px;
+    padding: 2rem;
+    background: var(--color-card);
+    border: 1px solid var(--color-border);
+    border-radius: 12px;
+    text-align: center;
+  }
+
+  h1 {
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: var(--color-primary);
+    margin: 0;
+  }
+
+  h1.failed {
+    color: var(--color-destructive);
+  }
+
+  p {
+    margin: 0;
+    color: var(--color-foreground);
+    line-height: 1.6;
+  }
+
+  .loading {
+    color: var(--color-muted);
+  }
+
+  .error {
+    color: var(--color-destructive);
+    font-size: 0.9375rem;
+  }
+
+  .hint {
+    color: var(--color-muted);
+    font-size: 0.8125rem;
+  }
+
+  .back-link {
+    color: var(--color-primary);
+    text-decoration: none;
+  }
+
+  .back-link:hover {
+    text-decoration: underline;
+  }
+</style>

--- a/manage.py
+++ b/manage.py
@@ -7,6 +7,7 @@ Usage:
     python manage.py wipe                         # Wipe database (destructive)
     python manage.py user-create <user> <pass>    # Create a user
     python manage.py server                       # Run the server
+    python manage.py migrate                      # Apply pending migrations
     python manage.py status                       # Show database status
 """
 import argparse
@@ -17,10 +18,15 @@ import subprocess
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from backend.database import db
-from backend.models import User, Board, Column, Card, Comment, Organization, OrganizationMember, Team, TeamMember
+from backend.models import ALL_MODELS, User
 
 
-TABLES = [User, Board, Column, Card, Comment, Organization, OrganizationMember, Team, TeamMember]
+# Read from backend.models rather than maintaining a second list. The old
+# hand-written copy here fell three tables behind (ApiKey, BetaSignup,
+# OrganizationInvite), so `init` built an incomplete schema and `status`
+# under-reported. This only ever went unnoticed because init_db() creates the
+# missing tables when the server next starts.
+TABLES = ALL_MODELS
 
 
 def cmd_init(args=None):
@@ -90,6 +96,65 @@ def cmd_server(args):
         print("\nServer stopped.")
 
 
+MIGRATIONS_DIR = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "backend", "migrations"
+)
+
+
+def _router():
+    import logging
+    from peewee_migrate import Router
+
+    # peewee-migrate reports what it applies through this logger; without a
+    # handler the deploy log would show nothing but our own prints.
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+    db.connect(reuse_if_open=True)
+    return Router(db, migrate_dir=MIGRATIONS_DIR)
+
+
+def cmd_migrate(args):
+    """Apply any migrations this database has not seen yet.
+
+    Safe to run on every deploy: peewee-migrate records applied migrations in
+    a migratehistory table and skips them next time. Each migration runs in a
+    transaction, so a failure rolls back rather than leaving a half-migrated
+    schema.
+    """
+    router = _router()
+
+    if args.list:
+        done = router.done
+        todo = [name for name in router.todo if name not in done]
+        print(f"Database: {db.database}")
+        print("Applied:")
+        for name in done or ["  (none)"]:
+            print(f"  {name}" if done else name)
+        print("Pending:")
+        for name in todo or ["  (none)"]:
+            print(f"  {name}" if todo else name)
+        return
+
+    pending = [name for name in router.todo if name not in router.done]
+    if not pending:
+        print("No pending migrations.")
+        return
+
+    print(f"Applying {len(pending)} migration(s): {', '.join(pending)}")
+    try:
+        applied = router.run(fake=args.fake)
+    except Exception as e:
+        # Non-zero exit matters: deploy.sh runs under `set -e`, and a deploy
+        # that restarts the service against an unmigrated database is an
+        # outage, not a warning.
+        print(f"\nMigration failed: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    for name in applied:
+        print(f"  applied {name}")
+    print("Migrations complete.")
+
+
 def cmd_status(args=None):
     """Show database status."""
     db.connect()
@@ -135,6 +200,11 @@ def main():
     sp_server.add_argument("--no-reload", dest="reload", action="store_false", help="Disable auto-reload")
     sp_server.set_defaults(func=cmd_server)
 
+    sp_migrate = subparsers.add_parser("migrate", help="Apply pending database migrations")
+    sp_migrate.add_argument("--list", action="store_true", help="Show applied and pending migrations without running any")
+    sp_migrate.add_argument("--fake", action="store_true", help="Record migrations as applied without running them")
+    sp_migrate.set_defaults(func=cmd_migrate)
+
     sp_status = subparsers.add_parser("status", help="Show database status")
     sp_status.set_defaults(func=cmd_status)
 
@@ -147,6 +217,7 @@ def main():
         print("  wipe               Wipe database (destructive)")
         print("  user-create        Create a new user")
         print("  server             Run the development server")
+        print("  migrate            Apply pending database migrations")
         print("  status             Show database status")
         print("\nServer options:")
         print("  --host HOST        Host to bind to (default: 0.0.0.0)")

--- a/manage.py
+++ b/manage.py
@@ -135,6 +135,11 @@ def cmd_migrate(args):
             print(f"  {name}" if todo else name)
         return
 
+    # Always name the database. There is more than one plausible path on a
+    # deployed box, and "which file did that actually touch" is the first
+    # question when a migration appears to have done nothing.
+    print(f"Database: {db.database}")
+
     pending = [name for name in router.todo if name not in router.done]
     if not pending:
         print("No pending migrations.")

--- a/sys/config/production.env
+++ b/sys/config/production.env
@@ -42,11 +42,16 @@ CORS_ORIGINS=https://kanban.pearachute.com
 #
 # The RESEND_FROM domain must be verified in Resend first, or every send is
 # rejected.
+#
+# Sends from pearachute.com, the apex, which is the domain verified in Resend
+# and the one the main site sends from. NOT kanban.pearachute.com: Resend
+# treats a subdomain as a separate domain needing its own DKIM records, so
+# sending from one that was never added fails every time.
 RESEND_API_KEY=
 # Quoted because of the angle brackets. systemd reads this file literally to
 # end of line and would not care, but deploy.sh also reads it, and an
 # unquoted "Kanban <noreply@...>" is a redirect to anything shell-based.
-RESEND_FROM="Kanban <noreply@kanban.pearachute.com>"
+RESEND_FROM="Kanban <noreply@pearachute.com>"
 
 # Origin used to build links in outgoing email. Not taken from the request
 # Host header, which is attacker-controlled.

--- a/sys/config/production.env
+++ b/sys/config/production.env
@@ -31,12 +31,23 @@ LOG_LEVEL=info
 # CORS Configuration (restrict origins in production)
 CORS_ORIGINS=https://kanban.pearachute.com
 
-# Email Configuration (optional, for future features)
-# SMTP_HOST=smtp.example.com
-# SMTP_PORT=587
-# SMTP_USER=noreply@example.com
-# SMTP_PASS=your-smtp-password
-# SMTP_TLS=true
+# Email Configuration (Resend)
+#
+# Used for signup verification links and organization invites.
+#
+# With RESEND_API_KEY unset the app still works, but mail is not sent -- the
+# message is printed to the service log instead. That is fine for development
+# and it means a missing key never breaks signup, but in production it means
+# nobody can verify their address and therefore nobody can log in.
+#
+# The RESEND_FROM domain must be verified in Resend first, or every send is
+# rejected.
+RESEND_API_KEY=
+RESEND_FROM=Kanban <noreply@kanban.pearachute.com>
+
+# Origin used to build links in outgoing email. Not taken from the request
+# Host header, which is attacker-controlled.
+PUBLIC_BASE_URL=https://kanban.pearachute.com
 
 # Rate Limiting (optional, for future features)
 # RATE_LIMIT_REQUESTS_PER_MINUTE=60

--- a/sys/config/production.env
+++ b/sys/config/production.env
@@ -43,7 +43,10 @@ CORS_ORIGINS=https://kanban.pearachute.com
 # The RESEND_FROM domain must be verified in Resend first, or every send is
 # rejected.
 RESEND_API_KEY=
-RESEND_FROM=Kanban <noreply@kanban.pearachute.com>
+# Quoted because of the angle brackets. systemd reads this file literally to
+# end of line and would not care, but deploy.sh also reads it, and an
+# unquoted "Kanban <noreply@...>" is a redirect to anything shell-based.
+RESEND_FROM="Kanban <noreply@kanban.pearachute.com>"
 
 # Origin used to build links in outgoing email. Not taken from the request
 # Host header, which is attacker-controlled.

--- a/sys/scripts/deploy.sh
+++ b/sys/scripts/deploy.sh
@@ -38,17 +38,24 @@ git_pull() {
     echo "Code updated"
 }
 
-# Function to update dependencies (if requirements changed)
+# Function to update dependencies
 update_dependencies() {
-    echo -e "${YELLOW}📦 Checking Python dependencies...${NC}"
+    echo -e "${YELLOW}📦 Installing Python dependencies...${NC}"
 
-    # Check if requirements.txt changed
-    if git diff --name-only HEAD~1 HEAD | grep -q "backend/requirements.txt"; then
-        echo "Requirements changed, updating..."
-        $DEPLOY_DIR/venv/bin/pip install -r $DEPLOY_DIR/backend/requirements.txt
-    else
-        echo "Requirements unchanged, skipping"
-    fi
+    # Unconditional, for the same reason as run_migrations below. The old
+    # `git diff HEAD~1 HEAD` guard only inspected the final commit of a push,
+    # so a multi-commit push that touched requirements.txt in an earlier
+    # commit skipped this entirely and left production missing a package.
+    #
+    # It also has to run before run_migrations: the migration runner imports
+    # peewee-migrate, so gating this step would mean the very deploy that
+    # introduces a dependency is the one that cannot use it.
+    #
+    # pip is a no-op when everything is already satisfied, so the cost of
+    # running it every time is a few seconds.
+    $DEPLOY_DIR/venv/bin/pip install -q -r $DEPLOY_DIR/backend/requirements.txt
+
+    echo "Dependencies up to date"
 }
 
 # Function to build frontend
@@ -66,16 +73,22 @@ build_frontend() {
 
 # Function to run database migrations
 run_migrations() {
-    echo -e "${YELLOW}🗄️ Checking for database migrations...${NC}"
+    echo -e "${YELLOW}🗄️ Running database migrations...${NC}"
 
-    # Check if migration files changed
-    if git diff --name-only HEAD~1 HEAD | grep -q "backend/migrations/"; then
-        echo "Migration files changed, checking database..."
-        # Add migration logic here if needed
-        echo "Migrations complete"
-    else
-        echo "No migrations needed"
-    fi
+    # Run unconditionally rather than gating on `git diff HEAD~1 HEAD`.
+    # peewee-migrate records what it has applied and skips the rest, so an
+    # up-to-date database costs one query. Gating on the diff was how this
+    # step silently did nothing: it only ever inspected the final commit of a
+    # push, and the body was a stub that printed success without running
+    # anything.
+    #
+    # This must happen before restart_service. The old code is still serving
+    # traffic at this point and does not know about the new columns, so
+    # migrating first means the new code never starts against an old schema.
+    cd $DEPLOY_DIR
+    $DEPLOY_DIR/venv/bin/python manage.py migrate
+
+    echo "Migrations complete"
 }
 
 # Function to restart service

--- a/sys/scripts/deploy.sh
+++ b/sys/scripts/deploy.sh
@@ -86,7 +86,27 @@ run_migrations() {
     # traffic at this point and does not know about the new columns, so
     # migrating first means the new code never starts against an old schema.
     cd $DEPLOY_DIR
-    $DEPLOY_DIR/venv/bin/python manage.py migrate
+
+    # Migrate the database the SERVICE uses, which is not necessarily the one
+    # manage.py would pick on its own. systemd sets DATABASE_PATH from
+    # /opt/kanban/.env (EnvironmentFile) falling back to the Environment= line
+    # in kanban.service; this shell has neither, so without the lookup below
+    # manage.py defaults to ./kanban.db and would happily migrate the wrong
+    # file -- leaving the live database untouched and unmigrated.
+    #
+    # Read rather than sourced: .env is systemd-format, where values are
+    # literal to end of line, so `RESEND_FROM=Kanban <noreply@...>` is valid
+    # there but would be a redirect to bash.
+    DB_PATH=""
+    if [ -f "$DEPLOY_DIR/.env" ]; then
+        DB_PATH=$(grep -E '^[[:space:]]*DATABASE_PATH=' "$DEPLOY_DIR/.env" \
+            | tail -1 | cut -d= -f2- | tr -d '"'"'"'' | xargs)
+    fi
+    # Matches Environment=DATABASE_PATH in sys/systemd/kanban.service.
+    DB_PATH="${DB_PATH:-$DEPLOY_DIR/kanban.db}"
+
+    echo "Target database: $DB_PATH"
+    DATABASE_PATH="$DB_PATH" $DEPLOY_DIR/venv/bin/python manage.py migrate
 
     echo "Migrations complete"
 }


### PR DESCRIPTION
Adds self-serve signup with Resend email verification, and fixes two deploy-pipeline bugs found while working out how to ship the migration it needs.

## Signup

People can create their own account instead of waiting on `manage.py user-create`.

| endpoint | does |
|---|---|
| `POST /api/signup` | creates the account with `email_verified=False` |
| `POST /api/verify-email` | consumes a single-use token, returns a JWT |
| `POST /api/resend-verification` | re-sends, 60s per-account cooldown |

`POST /api/token` returns 403 `"Email not verified"` until the link is clicked — checked *after* the password, so it can't be used to discover which accounts exist. `resend-verification` returns an identical response for known and unknown addresses for the same reason. Verification is POST rather than a GET link target because mail scanners follow GET URLs and would burn the token before the recipient clicked it.

**Signup grants no organization access.** It takes only username/email/password — no org field, no join path, no `OrganizationMember` row. The only ways into an existing org are still an owner adding you or an invite token; two tests pin that down.

`backend/mailer.py` posts to Resend using `requests`, already a dependency — no new package. With no `RESEND_API_KEY` set it prints the message to stderr and returns `False`, which is how local dev and the test suite work without a key. Sends never raise; a signup whose mail failed still creates the account.

Mail goes out from `noreply@pearachute.com`, not `kanban.pearachute.com` — Resend treats a subdomain as a separate domain needing its own DKIM records, and the apex is what's verified. It's also what the main site sends from, so both share one domain and one reputation to warm.

Also fixes the `/signup` link in `Invite.svelte`, which has been pointing at a route that didn't exist.

## Deploy pipeline

**`run_migrations()` never ran anything.** It checked whether migration files changed, printed `"Migrations complete"`, and returned — the body was a comment reading `# Add migration logic here if needed`. Migrations now run under peewee-migrate via `manage.py migrate`, before the service restarts, so a failure aborts the deploy instead of starting new code against an old schema.

Verified against copies of the production database in four states:

| state | result |
|---|---|
| 001 applied by hand, 002 never run | 001 no-ops, 002 backfills, exit 0 |
| fresh install | both no-op, exit 0 |
| re-run | "No pending migrations", exit 0 |
| duplicate emails | fails with named accounts, exit 1, nothing half-applied |

A migrated database and a fresh install end up with identical columns and indexes — which is why `002` names its index `user_email`, matching what `create_tables()` generates, rather than inventing a name.

It also migrates **the database the service actually uses**. The repo disagrees with itself about where that is (`production.env` and `DEPLOYMENT.md` say `/opt/kanban/data/kanban.db`; `kanban.service` and `install.sh` say `/opt/kanban/kanban.db`). systemd resolves it via `EnvironmentFile`; the deploy shell has no such thing, so without an explicit lookup `manage.py` would have defaulted to `./kanban.db` and migrated an empty file next to the real one.

**The health check could not fail.** It curled `/api/health` and accepted `200|404` — and that endpoint didn't exist. Accepting `404` was enough on its own to make it unfalsifiable; before main started 404ing unmatched `/api/` paths, the SPA catch-all answered them `200` with `index.html`, which made it doubly so. A broken database, a 500ing API and an unmigrated schema all reported healthy.

`/api/health` now exists and fetches a User row; the workflow matches on the response body.

> Worth a look during review: my first version of that endpoint used `.count()`, which peewee compiles to `SELECT COUNT(1) FROM (SELECT 1 FROM user LIMIT 1)` — naming none of the model's columns, so it reported healthy against an unmigrated database while `/api/token` was dying. It reproduced the exact blind spot it exists to close. It's `.first()` now, with a regression test I confirmed fails against the `.count()` version.

## Merged with main

Brought up to date with the 16 commits that landed since this branched. Two interacted:

- **`cd4d40a`** (404 unmatched `/api/` paths) — same root cause as the health check, fixed from the other end. No textual conflict, but it made several comments here wrong in the present tense; those are corrected, and the conclusion is unchanged.
- **`3651db6`** (deploy.sh change detection) — the only real conflict. Resolved toward main's `changed_since_previous` for the pip step, since that fix makes gating sound. `run_migrations` stays ungated on purpose, with a comment saying why: the helper answers "did migration files change in this push", but what matters is "does this database have unapplied migrations", and only the history table knows that. A failed deploy, a rollback, or a restore from an older backup all leave migrations pending with no diff to detect them.

One thing merged clean and still broke: `test_create_column_without_position_appends` assumed a new board starts empty, but the board-defaults commit at the base of this branch means it starts with three columns. The append behaviour is correct; only the starting state moved. CI on either branch alone would not have caught it.

## Heads-up on the first commit

`fix: create new boards with their default columns` was already sitting uncommitted in the working tree — it's not mine. I committed it separately so it stays reviewable on its own; drop it if it wasn't meant to go out yet.

## Deploying this

DNS is verified — DKIM at `resend._domainkey`, SPF scoped to `send.pearachute.com`, and the apex SPF for Google Workspace all confirmed live.

The remaining step is **`RESEND_API_KEY` in `/opt/kanban/.env`, then `sudo systemctl restart kanban`.** Until it's set, signup works but verification mail only reaches the service log — so no new account can log in. Existing accounts are unaffected: the migration backfills every pre-existing user to verified.

The deploy runs the migration automatically now. No manual step.

## Not addressed

Open signup plus outbound email is a spam vector and there's **no rate limiting anywhere in this stack**. The 60s cooldown is a speed bump, not a defense. Tracked as card #49, with #51 for CI migration/schema-drift coverage. (#50, the deploy.sh baseline bug, was fixed independently on main.)

## Testing

264 passed, 1 skipped. Signup, verification, login gating, and the invite→signup→verify path were also driven end-to-end in a browser against a throwaway database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
