### PR TITLE
feat: --json output mode for scripting the CLI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,25 @@ kanban board get 1                    # Show Dev board details
 kanban board get <id>                 # Show board with columns & cards
 ```
 
+### Scripting the CLI
+
+Pass `--json` (or set `KANBAN_OUTPUT=json`) and every command prints the raw
+API response instead of formatted text. Use it rather than parsing the human
+output — the prose is not an interface, and a reworded string silently breaks
+anything that regexes it.
+
+```bash
+kanban column create 1 Todo 0 --json | jq -r .id
+kanban board get 1 --json | jq '.columns[].cards[] | {id, title, description}'
+```
+
+The flag works before or after the subcommand. In JSON mode stdout holds only
+the response; errors go to stderr as `{"error": ..., "status": ...}` alongside
+a non-zero exit code, so stdout is always safe to pipe into a parser.
+
+Note there is still no `card get` — a single card's description is only
+reachable through `board get <id> --json`.
+
 ## Build, Lint, and Test Commands
 
 ### Setup

--- a/README.md
+++ b/README.md
@@ -63,6 +63,30 @@ kanban --api-key kanban_abc123... board list
 
 API keys can be revoked and reactivated at any time. They're stored securely (bcrypt-hashed) and track their last usage.
 
+## Scripting: JSON output
+
+`--json` makes any command print the raw API response instead of formatted
+text, so scripts never have to scrape prose for values like IDs:
+
+```bash
+kanban board create "Roadmap" --json
+kanban board get 1 --json | jq '.columns[] | {id, name}'
+```
+
+`KANBAN_OUTPUT=json` does the same for a whole run:
+
+```bash
+export KANBAN_OUTPUT=json
+```
+
+The flag works in either position (`kanban --json board list` and
+`kanban board list --json` are equivalent). In JSON mode stdout carries only
+the response, and errors go to stderr as `{"error": ..., "status": ...}` with a
+non-zero exit code — so stdout is always safe to pipe into a parser.
+
+`kanban login --json` deliberately omits the access token: it is already saved
+to `~/.kanban.yaml`, and stdout is what CI logs capture.
+
 ## Command Reference
 
 | Command | Description |
@@ -71,6 +95,7 @@ API keys can be revoked and reactivated at any time. They're stored securely (bc
 | `kanban login <user> --password <pass>` | Login to the server |
 | `kanban logout` | Logout and clear credentials |
 | `kanban --api-key <key>` | Use API key for authentication |
+| `kanban --json <command>` | Print the raw API response as JSON |
 | `kanban apikey create <name>` | Generate a new API key |
 | `kanban apikey list` | List your API keys |
 | `kanban apikey revoke <id>` | Revoke an API key |

--- a/backend/tests/test_cli.py
+++ b/backend/tests/test_cli.py
@@ -427,3 +427,157 @@ def test_describe_http_error_prefers_server_detail():
 
     message = describe_http_error(requests.exceptions.HTTPError(response=response))
     assert message == "Board not found"
+
+
+# === Machine-readable output (--json / KANBAN_OUTPUT=json) ===
+
+
+@pytest.fixture
+def json_mode():
+    """Turn on JSON output for one test and put it back afterwards."""
+    from kanban.output import set_json_output
+
+    set_json_output(True)
+    yield
+    set_json_output(None)
+
+
+@pytest.fixture(autouse=True)
+def _reset_output_mode():
+    from kanban.output import set_json_output
+
+    set_json_output(None)
+    yield
+    set_json_output(None)
+
+
+def test_json_output_emits_raw_api_response(capsys, json_mode):
+    """--json prints the API payload verbatim, so a script can index into it
+    instead of regexing prose out of the human rendering."""
+    import json
+    from kanban.cli import cmd_boards
+
+    payload = [
+        {"id": 1, "name": "Dev", "shared_team_id": 1},
+        {"id": 3, "name": "Other", "shared_team_id": None},
+    ]
+    mock_client = MagicMock()
+    mock_client.boards.return_value = payload
+
+    with patch("kanban.cli.make_client", return_value=mock_client):
+        cmd_boards()
+
+    assert json.loads(capsys.readouterr().out) == payload
+
+
+def test_json_output_gives_ids_without_parsing_prose(capsys, json_mode):
+    """The case from the ticket: 'Column created with id=17' needed a regex.
+    The id now comes off a parsed object."""
+    import json
+    from kanban.cli import cmd_column_create
+
+    mock_client = MagicMock()
+    mock_client.column_create.return_value = {"id": 17, "name": "Todo", "position": 0}
+
+    with patch("kanban.cli.make_client", return_value=mock_client):
+        cmd_column_create(board_id=1, name="Todo", position=0)
+
+    assert json.loads(capsys.readouterr().out)["id"] == 17
+
+
+def test_human_output_is_unchanged_by_default(capsys):
+    from kanban.cli import cmd_column_create
+
+    mock_client = MagicMock()
+    mock_client.column_create.return_value = {"id": 17}
+
+    with patch("kanban.cli.make_client", return_value=mock_client):
+        cmd_column_create(board_id=1, name="Todo", position=0)
+
+    out = capsys.readouterr().out
+    assert "Column created with id=17" in out
+    assert "{" not in out
+
+
+def test_kanban_output_env_var_selects_json(capsys, monkeypatch):
+    import json
+    from kanban.cli import cmd_boards
+
+    monkeypatch.setenv("KANBAN_OUTPUT", "json")
+
+    mock_client = MagicMock()
+    mock_client.boards.return_value = [{"id": 1, "name": "Dev"}]
+
+    with patch("kanban.cli.make_client", return_value=mock_client):
+        cmd_boards()
+
+    assert json.loads(capsys.readouterr().out) == [{"id": 1, "name": "Dev"}]
+
+
+def test_json_errors_go_to_stderr_leaving_stdout_parseable(capsys, json_mode):
+    """A script must be able to parse stdout without first checking whether it
+    holds a result or an error message."""
+    import json
+    import requests
+    import typer
+    from kanban.cli import cmd_card_delete
+
+    response = MagicMock()
+    response.status_code = 404
+    mock_client = MagicMock()
+    mock_client.card_delete.side_effect = requests.exceptions.HTTPError(
+        response=response
+    )
+
+    with patch("kanban.cli.make_client", return_value=mock_client):
+        with pytest.raises(typer.Exit):
+            cmd_card_delete(card_id=42)
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    error = json.loads(captured.err)
+    assert error["status"] == 404
+    assert "42" in error["error"]
+
+
+def test_json_login_does_not_print_the_access_token(capsys, json_mode):
+    """The token is already saved to config, and stdout is what CI logs."""
+    import json
+    from kanban.cli import cmd_login
+
+    mock_client = MagicMock()
+    mock_client.login.return_value = "secret-token-value"
+
+    with patch("kanban.cli.KanbanClient", return_value=mock_client):
+        cmd_login(username="alice", password="pw", server=None)
+
+    captured = capsys.readouterr()
+    assert "secret-token-value" not in captured.out
+    assert json.loads(captured.out)["username"] == "alice"
+
+
+@pytest.mark.parametrize(
+    "argv,expected_found,expected_argv",
+    [
+        # Typed after the subcommand -- click would reject it, so main() strips it.
+        (
+            ["kanban", "board", "list", "--json"],
+            True,
+            ["kanban", "board", "list"],
+        ),
+        # Typed as a root option, which click would accept anyway.
+        (["kanban", "--json", "board", "list"], True, ["kanban", "board", "list"]),
+        (["kanban", "board", "list"], False, ["kanban", "board", "list"]),
+        # Following an option, "--json" is that option's value, not our flag.
+        (
+            ["kanban", "card", "create", "1", "t", "--description", "--json"],
+            False,
+            ["kanban", "card", "create", "1", "t", "--description", "--json"],
+        ),
+    ],
+)
+def test_extract_json_flag_positions(argv, expected_found, expected_argv):
+    from kanban.cli import _extract_json_flag
+
+    assert _extract_json_flag(argv) is expected_found
+    assert argv == expected_argv

--- a/kanban/cli.py
+++ b/kanban/cli.py
@@ -17,6 +17,7 @@ from kanban.config import (
     get_runtime_api_key,
     set_runtime_api_key,
 )
+from kanban.output import emit, emit_error, set_json_output
 
 app = typer.Typer(
     help="Kanban board CLI", no_args_is_help=True, invoke_without_command=True
@@ -27,7 +28,7 @@ def _version_callback(value: bool):
     if value:
         from kanban import __version__
 
-        rprint(f"kanban {__version__}")
+        emit({"version": __version__}, lambda: rprint(f"kanban {__version__}"))
         raise typer.Exit()
 
 
@@ -41,8 +42,19 @@ def _root(
         callback=_version_callback,
         is_eager=True,
     ),
+    json_out: bool = typer.Option(
+        False,
+        "--json",
+        help="Print the raw API response as JSON instead of formatted text. "
+        "Can also be set with KANBAN_OUTPUT=json.",
+    ),
 ):
     """Kanban board CLI"""
+    # main() usually strips --json before typer sees it, so this only fires
+    # when app() is invoked directly. Declaring it here is what puts it in
+    # `kanban --help`.
+    if json_out:
+        set_json_output(True)
 
 
 def describe_http_error(e):
@@ -87,9 +99,7 @@ def make_client():
     token = get_token()
     api_key = get_api_key()
     if not token and not api_key:
-        rprint(
-            "[red]Not authenticated. Run 'kanban login' first or use --api-key.[/red]"
-        )
+        emit_error("Not authenticated. Run 'kanban login' first or use --api-key.")
         raise typer.Exit(1)
     return KanbanClient(token=token, api_key=api_key)
 
@@ -104,9 +114,16 @@ def cmd_config(
     """Configure the CLI or show current settings."""
     if url:
         set_server_url(url)
-        rprint(f"Server URL set to: [green]{url}[/green]")
+        emit(
+            {"server_url": url},
+            lambda: rprint(f"Server URL set to: [green]{url}[/green]"),
+        )
     else:
-        rprint(f"Server URL: [cyan]{get_server_url()}[/cyan]")
+        current = get_server_url()
+        emit(
+            {"server_url": current},
+            lambda: rprint(f"Server URL: [cyan]{current}[/cyan]"),
+        )
 
 
 @app.command("login")
@@ -137,7 +154,7 @@ def cmd_login(
     try:
         token = client.login(username, password)
     except Exception as e:
-        rprint(f"[red]Login failed: {e}[/red]")
+        emit_error(f"Login failed: {e}")
         raise typer.Exit(1)
     # Only after a successful login: the token was issued by server_url, so
     # every later command has to talk to that same server. Persist an explicit
@@ -145,14 +162,19 @@ def cmd_login(
     set_token(token)
     if server is not None:
         set_server_url(server_url)
-    rprint(f"Logged in as [green]{username}[/green]")
+    # The access token is deliberately left out of the JSON: it is already
+    # saved to the config file, and stdout is exactly what CI logs capture.
+    emit(
+        {"ok": True, "username": username, "server_url": server_url},
+        lambda: rprint(f"Logged in as [green]{username}[/green]"),
+    )
 
 
 @app.command("logout")
 def cmd_logout():
     """Logout and clear credentials."""
     clear_token()
-    rprint("Logged out")
+    emit({"ok": True}, lambda: rprint("Logged out"))
 
 
 # === Board Commands ===
@@ -166,16 +188,20 @@ def cmd_boards():
     """List all boards."""
     client = make_client()
     boards = client.boards()
-    if not boards:
-        rprint("No boards found")
-        return
-    for b in boards:
-        shared_info = ""
-        if b.get("shared_team_id"):
-            shared_info = f" (shared with team {b['shared_team_id']})"
-        elif b.get("is_public_to_org"):
-            shared_info = " (public to organization)"
-        rprint(f"{b['id']:4}  [bold]{b['name']}[/bold]{shared_info}")
+
+    def render():
+        if not boards:
+            rprint("No boards found")
+            return
+        for b in boards:
+            shared_info = ""
+            if b.get("shared_team_id"):
+                shared_info = f" (shared with team {b['shared_team_id']})"
+            elif b.get("is_public_to_org"):
+                shared_info = " (public to organization)"
+            rprint(f"{b['id']:4}  [bold]{b['name']}[/bold]{shared_info}")
+
+    emit(boards, render)
 
 
 @board_app.command("create")
@@ -183,7 +209,7 @@ def cmd_board_create(name: str = typer.Argument(..., help="Board name")):
     """Create a new board."""
     client = make_client()
     result = client.board_create(name)
-    rprint(f"Board created with [green]id={result['id']}[/green]")
+    emit(result, lambda: rprint(f"Board created with [green]id={result['id']}[/green]"))
 
 
 @board_app.command("get")
@@ -194,27 +220,31 @@ def cmd_board_get(board_id: int = typer.Argument(..., help="Board ID")):
 
     client = make_client()
     board = client.board_get(board_id)
-    console = Console()
-    console.print(f"Board: [bold]{board['name']}[/bold]")
-    for col in board.get("columns", []):
-        line = Text("  ")
-        line.append(f"#{col['id']}", style="yellow")
-        line.append(f" {col['name']}")
-        line.append(f" ({len(col['cards'])} cards)")
-        console.print(line)
-        for card in col.get("cards", []):
-            card_line = Text("    - ")
-            card_line.append(f"#{card['id']}", style="yellow")
-            card_line.append(f" {card['title']}")
-            console.print(card_line)
+
+    def render():
+        console = Console()
+        console.print(f"Board: [bold]{board['name']}[/bold]")
+        for col in board.get("columns", []):
+            line = Text("  ")
+            line.append(f"#{col['id']}", style="yellow")
+            line.append(f" {col['name']}")
+            line.append(f" ({len(col['cards'])} cards)")
+            console.print(line)
+            for card in col.get("cards", []):
+                card_line = Text("    - ")
+                card_line.append(f"#{card['id']}", style="yellow")
+                card_line.append(f" {card['title']}")
+                console.print(card_line)
+
+    emit(board, render)
 
 
 @board_app.command("delete")
 def cmd_board_delete(board_id: int = typer.Argument(..., help="Board ID")):
     """Delete a board."""
     client = make_client()
-    client.board_delete(board_id)
-    rprint("[green]Board deleted[/green]")
+    result = client.board_delete(board_id)
+    emit(result, lambda: rprint("[green]Board deleted[/green]"))
 
 
 @board_app.command("update")
@@ -224,8 +254,8 @@ def cmd_board_update(
 ):
     """Update board name."""
     client = make_client()
-    client.board_update(board_id, name)
-    rprint("[green]Board updated[/green]")
+    result = client.board_update(board_id, name)
+    emit(result, lambda: rprint("[green]Board updated[/green]"))
 
 
 # === Column Commands ===
@@ -243,15 +273,17 @@ def cmd_column_create(
     """Create a new column."""
     client = make_client()
     result = client.column_create(board_id, name, position)
-    rprint(f"Column created with [green]id={result['id']}[/green]")
+    emit(
+        result, lambda: rprint(f"Column created with [green]id={result['id']}[/green]")
+    )
 
 
 @column_app.command("delete")
 def cmd_column_delete(column_id: int = typer.Argument(..., help="Column ID")):
     """Delete a column."""
     client = make_client()
-    client.column_delete(column_id)
-    rprint("[green]Column deleted[/green]")
+    result = client.column_delete(column_id)
+    emit(result, lambda: rprint("[green]Column deleted[/green]"))
 
 
 # === Card Commands ===
@@ -272,7 +304,7 @@ def cmd_card_create(
     """Create a new card."""
     client = make_client()
     result = client.card_create(column_id, title, description, position)
-    rprint(f"Card created with [green]id={result['id']}[/green]")
+    emit(result, lambda: rprint(f"Card created with [green]id={result['id']}[/green]"))
 
 
 @card_app.command("update")
@@ -288,19 +320,19 @@ def cmd_card_update(
     """Update a card."""
     client = make_client()
     try:
-        client.card_update(card_id, title, description, position, column)
-        rprint("[green]Card updated[/green]")
+        result = client.card_update(card_id, title, description, position, column)
+        emit(result, lambda: rprint("[green]Card updated[/green]"))
     except requests.exceptions.HTTPError as e:
-        if e.response.status_code == 404:
-            rprint(f"[red]Card {card_id} not found. It may have been deleted.[/red]")
-        elif e.response.status_code == 403:
-            rprint("[red]You don't have permission to update this card.[/red]")
-        elif e.response.status_code == 422:
-            rprint(
-                "[red]Invalid data. Check that the card ID and column ID are correct.[/red]"
-            )
+        status = e.response.status_code
+        if status == 404:
+            message = f"Card {card_id} not found. It may have been deleted."
+        elif status == 403:
+            message = "You don't have permission to update this card."
+        elif status == 422:
+            message = "Invalid data. Check that the card ID and column ID are correct."
         else:
-            rprint(f"[red]Error: {e.response.text}[/red]")
+            message = f"Error: {e.response.text}"
+        emit_error(message, status=status)
         raise typer.Exit(1)
 
 
@@ -309,17 +341,17 @@ def cmd_card_delete(card_id: int = typer.Argument(..., help="Card ID")):
     """Delete a card."""
     client = make_client()
     try:
-        client.card_delete(card_id)
-        rprint("[green]Card deleted[/green]")
+        result = client.card_delete(card_id)
+        emit(result, lambda: rprint("[green]Card deleted[/green]"))
     except requests.exceptions.HTTPError as e:
-        if e.response.status_code == 404:
-            rprint(
-                f"[red]Card {card_id} not found. It may have already been deleted.[/red]"
-            )
-        elif e.response.status_code == 403:
-            rprint("[red]You don't have permission to delete this card.[/red]")
+        status = e.response.status_code
+        if status == 404:
+            message = f"Card {card_id} not found. It may have already been deleted."
+        elif status == 403:
+            message = "You don't have permission to delete this card."
         else:
-            rprint(f"[red]Error: {e.response.text}[/red]")
+            message = f"Error: {e.response.text}"
+        emit_error(message, status=status)
         raise typer.Exit(1)
 
 
@@ -334,13 +366,17 @@ def cmd_organizations():
     """List all organizations."""
     client = make_client()
     orgs = client.organizations()
-    if not orgs:
-        rprint("No organizations found")
-        return
-    for org in orgs:
-        rprint(
-            f"{org['id']:4}  [bold]{org['name']}[/bold] (owner: {org.get('owner_username', 'Unknown')})"
-        )
+
+    def render():
+        if not orgs:
+            rprint("No organizations found")
+            return
+        for org in orgs:
+            rprint(
+                f"{org['id']:4}  [bold]{org['name']}[/bold] (owner: {org.get('owner_username', 'Unknown')})"
+            )
+
+    emit(orgs, render)
 
 
 @org_app.command("create")
@@ -348,7 +384,10 @@ def cmd_organization_create(name: str = typer.Argument(..., help="Organization n
     """Create a new organization."""
     client = make_client()
     result = client.organization_create(name)
-    rprint(f"Organization created with [green]id={result['id']}[/green]")
+    emit(
+        result,
+        lambda: rprint(f"Organization created with [green]id={result['id']}[/green]"),
+    )
 
 
 @org_app.command("get")
@@ -356,12 +395,17 @@ def cmd_organization_get(org_id: int = typer.Argument(..., help="Organization ID
     """Show organization details."""
     client = make_client()
     org = client.organization_get(org_id)
-    rprint(f"Organization: [bold]{org['name']}[/bold]")
-    rprint(f"Owner: {org.get('owner_username', 'Unknown')}")
-    rprint("Members:")
-    for member in org.get("members", []):
-        role_info = f" ({member.get('role', 'member')})" if member.get("role") else ""
-        rprint(f"  - {member['username']}{role_info}")
+
+    def render():
+        rprint(f"Organization: [bold]{org['name']}[/bold]")
+        rprint(f"Owner: {org.get('owner_username', 'Unknown')}")
+        rprint("Members:")
+        for member in org.get("members", []):
+            role = member.get("role")
+            role_info = f" ({role or 'member'})" if role else ""
+            rprint(f"  - {member['username']}{role_info}")
+
+    emit(org, render)
 
 
 @org_app.command("members")
@@ -369,9 +413,14 @@ def cmd_organization_members(org_id: int = typer.Argument(..., help="Organizatio
     """List organization members."""
     client = make_client()
     members = client.organization_members(org_id)
-    for member in members:
-        role_info = f" ({member.get('role', 'member')})" if member.get("role") else ""
-        rprint(f"{member['id']:4}  {member['username']}{role_info}")
+
+    def render():
+        for member in members:
+            role = member.get("role")
+            role_info = f" ({role or 'member'})" if role else ""
+            rprint(f"{member['id']:4}  {member['username']}{role_info}")
+
+    emit(members, render)
 
 
 @org_app.command("member-add")
@@ -381,8 +430,8 @@ def cmd_organization_member_add(
 ):
     """Add member to organization."""
     client = make_client()
-    client.organization_member_add(org_id, username)
-    rprint(f"Added [green]{username}[/green] to organization")
+    result = client.organization_member_add(org_id, username)
+    emit(result, lambda: rprint(f"Added [green]{username}[/green] to organization"))
 
 
 @org_app.command("member-remove")
@@ -392,8 +441,11 @@ def cmd_organization_member_remove(
 ):
     """Remove member from organization."""
     client = make_client()
-    client.organization_member_remove(org_id, user_id)
-    rprint(f"Removed user [green]{user_id}[/green] from organization")
+    result = client.organization_member_remove(org_id, user_id)
+    emit(
+        result,
+        lambda: rprint(f"Removed user [green]{user_id}[/green] from organization"),
+    )
 
 
 # === Organization Invite Commands ===
@@ -409,12 +461,18 @@ def cmd_organization_invite_create(
     result = client.organization_invite_create(org_id, email)
     server_url = get_server_url()
     invite_link = f"{server_url.rstrip('/')}/#!/invite/{result['token']}"
-    rprint(f"[bold]Invite created![/bold]")
-    rprint(f"  ID:       {result['id']}")
-    rprint(f"  Email:    {email or '(anonymous)'}")
-    rprint(f"  Link:    [cyan]{invite_link}[/cyan]")
-    rprint("")
-    rprint("Share this link with the person you want to invite.")
+
+    def render():
+        rprint("[bold]Invite created![/bold]")
+        rprint(f"  ID:       {result['id']}")
+        rprint(f"  Email:    {email or '(anonymous)'}")
+        rprint(f"  Link:    [cyan]{invite_link}[/cyan]")
+        rprint("")
+        rprint("Share this link with the person you want to invite.")
+
+    # The link is assembled here, not by the server, so a script would have to
+    # rebuild it from the token -- hand it over alongside the raw response.
+    emit({**result, "invite_url": invite_link}, render)
 
 
 @org_app.command("invite-list")
@@ -422,15 +480,20 @@ def cmd_organization_invites(org_id: int = typer.Argument(..., help="Organizatio
     """List pending invites for an organization."""
     client = make_client()
     invites = client.organization_invites(org_id)
-    if not invites:
-        rprint("No pending invites")
-        return
-    rprint("[bold]Pending Invites:[/bold]")
-    for invite in invites:
-        rprint(f"  {invite['id']:4}  {invite['email'] or '(anonymous)'}")
-        rprint(
-            f"       Link: {get_server_url().rstrip('/')}/#!/invite/{invite['token']}"
-        )
+    base = get_server_url().rstrip("/")
+
+    def render():
+        if not invites:
+            rprint("No pending invites")
+            return
+        rprint("[bold]Pending Invites:[/bold]")
+        for invite in invites:
+            rprint(f"  {invite['id']:4}  {invite['email'] or '(anonymous)'}")
+            rprint(f"       Link: {base}/#!/invite/{invite['token']}")
+
+    emit(
+        [{**i, "invite_url": f"{base}/#!/invite/{i['token']}"} for i in invites], render
+    )
 
 
 @org_app.command("invite-revoke")
@@ -440,8 +503,10 @@ def cmd_organization_invite_revoke(
 ):
     """Revoke a pending invite."""
     client = make_client()
-    client.organization_invite_revoke(org_id, invite_id)
-    rprint(f"Invite [green]{invite_id}[/green] has been revoked")
+    result = client.organization_invite_revoke(org_id, invite_id)
+    emit(
+        result, lambda: rprint(f"Invite [green]{invite_id}[/green] has been revoked")
+    )
 
 
 # === Team Commands ===
@@ -459,13 +524,17 @@ def cmd_teams(
     """List teams in an organization."""
     client = make_client()
     teams = client.organization_teams(org_id)
-    if not teams:
-        rprint("No teams found")
-        return
-    for team in teams:
-        rprint(
-            f"{team['id']:4}  [bold]{team['name']}[/bold] (org: {team.get('organization_name', 'Unknown')})"
-        )
+
+    def render():
+        if not teams:
+            rprint("No teams found")
+            return
+        for team in teams:
+            rprint(
+                f"{team['id']:4}  [bold]{team['name']}[/bold] (org: {team.get('organization_name', 'Unknown')})"
+            )
+
+    emit(teams, render)
 
 
 @team_app.command("create")
@@ -476,7 +545,7 @@ def cmd_team_create(
     """Create a new team."""
     client = make_client()
     result = client.team_create(org_id, name)
-    rprint(f"Team created with [green]id={result['id']}[/green]")
+    emit(result, lambda: rprint(f"Team created with [green]id={result['id']}[/green]"))
 
 
 @team_app.command("get")
@@ -484,11 +553,15 @@ def cmd_team_get(team_id: int = typer.Argument(..., help="Team ID")):
     """Show team details."""
     client = make_client()
     team = client.team_get(team_id)
-    rprint(f"Team: [bold]{team['name']}[/bold]")
-    rprint(f"Organization: {team.get('organization_name', 'Unknown')}")
-    rprint("Members:")
-    for member in team.get("members", []):
-        rprint(f"  - {member['username']}")
+
+    def render():
+        rprint(f"Team: [bold]{team['name']}[/bold]")
+        rprint(f"Organization: {team.get('organization_name', 'Unknown')}")
+        rprint("Members:")
+        for member in team.get("members", []):
+            rprint(f"  - {member['username']}")
+
+    emit(team, render)
 
 
 @team_app.command("members")
@@ -496,8 +569,12 @@ def cmd_team_members(team_id: int = typer.Argument(..., help="Team ID")):
     """List team members."""
     client = make_client()
     members = client.team_members(team_id)
-    for member in members:
-        rprint(f"{member['id']:4}  {member['username']}")
+
+    def render():
+        for member in members:
+            rprint(f"{member['id']:4}  {member['username']}")
+
+    emit(members, render)
 
 
 @team_app.command("member-add")
@@ -507,8 +584,8 @@ def cmd_team_member_add(
 ):
     """Add member to team."""
     client = make_client()
-    client.team_member_add(team_id, username)
-    rprint(f"Added [green]{username}[/green] to team")
+    result = client.team_member_add(team_id, username)
+    emit(result, lambda: rprint(f"Added [green]{username}[/green] to team"))
 
 
 @team_app.command("member-remove")
@@ -518,8 +595,8 @@ def cmd_team_member_remove(
 ):
     """Remove member from team."""
     client = make_client()
-    client.team_member_remove(team_id, user_id)
-    rprint(f"Removed user [green]{user_id}[/green] from team")
+    result = client.team_member_remove(team_id, user_id)
+    emit(result, lambda: rprint(f"Removed user [green]{user_id}[/green] from team"))
 
 
 # === Board Sharing ===
@@ -535,11 +612,15 @@ def cmd_board_share(
     """Share board with team or make private."""
     client = make_client()
     team_id_value = None if team_id == "private" else team_id
-    client.board_share(board_id, team_id_value)
-    if team_id_value:
-        rprint(f"Board [green]{board_id}[/green] shared with team {team_id_value}")
-    else:
-        rprint(f"Board [green]{board_id}[/green] made private")
+    result = client.board_share(board_id, team_id_value)
+
+    def render():
+        if team_id_value:
+            rprint(f"Board [green]{board_id}[/green] shared with team {team_id_value}")
+        else:
+            rprint(f"Board [green]{board_id}[/green] made private")
+
+    emit(result, render)
 
 
 # === API Key Commands ===
@@ -553,17 +634,23 @@ def cmd_apikey_list():
     """List all API keys."""
     client = make_client()
     keys = client.api_keys()
-    if not keys:
-        rprint("No API keys found")
-        return
-    rprint("[bold]Your API Keys:[/bold]")
-    for key in keys:
-        status = "[green]active[/green]" if key["is_active"] else "[red]inactive[/red]"
-        last_used = key["last_used_at"][:10] if key["last_used_at"] else "never"
-        expires = key["expires_at"][:10] if key["expires_at"] else "never"
-        rprint(
-            f"  {key['prefix']}....  {key['name']}  {status}  last used: {last_used}  expires: {expires}"
-        )
+
+    def render():
+        if not keys:
+            rprint("No API keys found")
+            return
+        rprint("[bold]Your API Keys:[/bold]")
+        for key in keys:
+            status = (
+                "[green]active[/green]" if key["is_active"] else "[red]inactive[/red]"
+            )
+            last_used = key["last_used_at"][:10] if key["last_used_at"] else "never"
+            expires = key["expires_at"][:10] if key["expires_at"] else "never"
+            rprint(
+                f"  {key['prefix']}....  {key['name']}  {status}  last used: {last_used}  expires: {expires}"
+            )
+
+    emit(keys, render)
 
 
 @apikey_app.command("create")
@@ -573,15 +660,19 @@ def cmd_apikey_create(
     """Create a new API key. The key is shown only once - save it securely!"""
     client = make_client()
     result = client.api_key_create(name)
-    rprint(f"[bold]API Key created![/bold]")
-    rprint("")
-    rprint(f"  Name:    {result['name']}")
-    rprint(f"  Key:     [yellow]{result['key']}[/yellow]")
-    rprint(f"  Prefix:  {result['prefix']}....")
-    rprint("")
-    rprint(
-        "[yellow]IMPORTANT: This key is shown only once! Copy it now and store it securely.[/yellow]"
-    )
+
+    def render():
+        rprint("[bold]API Key created![/bold]")
+        rprint("")
+        rprint(f"  Name:    {result['name']}")
+        rprint(f"  Key:     [yellow]{result['key']}[/yellow]")
+        rprint(f"  Prefix:  {result['prefix']}....")
+        rprint("")
+        rprint(
+            "[yellow]IMPORTANT: This key is shown only once! Copy it now and store it securely.[/yellow]"
+        )
+
+    emit(result, render)
 
 
 @apikey_app.command("revoke")
@@ -589,10 +680,12 @@ def cmd_apikey_revoke(key_id: int = typer.Argument(..., help="API key ID to revo
     """Revoke (deactivate) an API key."""
     client = make_client()
     try:
-        client.api_key_revoke(key_id)
-        rprint(f"API key [green]{key_id}[/green] has been revoked")
+        result = client.api_key_revoke(key_id)
+        emit(
+            result, lambda: rprint(f"API key [green]{key_id}[/green] has been revoked")
+        )
     except Exception as e:
-        rprint(f"[red]Failed to revoke key: {e}[/red]")
+        emit_error(f"Failed to revoke key: {e}")
         raise typer.Exit(1)
 
 
@@ -603,10 +696,12 @@ def cmd_apikey_activate(
     """Reactivate a deactivated API key."""
     client = make_client()
     try:
-        client.api_key_activate(key_id)
-        rprint(f"API key [green]{key_id}[/green] has been activated")
+        result = client.api_key_activate(key_id)
+        emit(
+            result, lambda: rprint(f"API key [green]{key_id}[/green] has been activated")
+        )
     except Exception as e:
-        rprint(f"[red]Failed to activate key: {e}[/red]")
+        emit_error(f"Failed to activate key: {e}")
         raise typer.Exit(1)
 
 
@@ -630,12 +725,16 @@ def cmd_apikey_use(
 
         # Verify the key works by listing boards
         boards = client.boards()
-        rprint(f"[green]API key verified[/green] - found {len(boards)} board(s)")
-        rprint(
-            f"Run your command directly with: [cyan]kanban --api-key {key} <command>[/cyan]"
-        )
+
+        def render():
+            rprint(f"[green]API key verified[/green] - found {len(boards)} board(s)")
+            rprint(
+                f"Run your command directly with: [cyan]kanban --api-key {key} <command>[/cyan]"
+            )
+
+        emit({"ok": True, "board_count": len(boards)}, render)
     except Exception as e:
-        rprint(f"[red]API key verification failed: {e}[/red]")
+        emit_error(f"API key verification failed: {e}")
         raise typer.Exit(1)
 
 
@@ -645,12 +744,38 @@ def cmd_apikey_save(key: str = typer.Argument(..., help="API key to save")):
     from kanban.config import set_api_key
 
     set_api_key(key)
-    rprint("[green]API key saved to ~/.kanban.yaml[/green]")
-    rprint("Run commands without --api-key from now on.")
+
+    def render():
+        rprint("[green]API key saved to ~/.kanban.yaml[/green]")
+        rprint("Run commands without --api-key from now on.")
+
+    emit({"ok": True}, render)
+
+
+def _extract_json_flag(argv):
+    """Pull `--json` off the command line wherever it appears.
+
+    Click only accepts an option on the command that declares it, so
+    `kanban --json board list` would work while `kanban board list --json`
+    failed -- and the second form is the one people type. Strip it here
+    instead, the same trick `--api-key` already uses.
+
+    A `--json` sitting right after another option is left alone: there it is
+    that option's value (`--description --json`), not a flag of ours.
+    """
+    found = False
+    for i in range(len(argv) - 1, 0, -1):
+        if argv[i] == "--json" and not argv[i - 1].startswith("-"):
+            argv.pop(i)
+            found = True
+    return found
 
 
 def main():
     """Main entry point for the CLI."""
+    if _extract_json_flag(sys.argv):
+        set_json_output(True)
+
     # Check for --api-key option
     if "--api-key" in sys.argv or "-k" in sys.argv:
         idx = None
@@ -671,10 +796,11 @@ def main():
     try:
         app()
     except KanbanError as e:
-        rprint(f"[red]{e}[/red]")
+        emit_error(str(e))
         raise SystemExit(1)
     except requests.exceptions.HTTPError as e:
-        rprint(f"[red]{describe_http_error(e)}[/red]")
+        extra = {} if e.response is None else {"status": e.response.status_code}
+        emit_error(describe_http_error(e), **extra)
         raise SystemExit(1)
 
 

--- a/kanban/client.py
+++ b/kanban/client.py
@@ -77,8 +77,7 @@ class KanbanClient:
         return self._request("POST", f"/api/boards/{board_id}", json={"name": name})
 
     def board_delete(self, board_id):
-        self._request("DELETE", f"/api/boards/{board_id}")
-        return True
+        return self._request("DELETE", f"/api/boards/{board_id}")
 
     def column_create(self, board_id, name, position):
         return self._request(
@@ -95,8 +94,7 @@ class KanbanClient:
         )
 
     def column_delete(self, column_id):
-        self._request("DELETE", f"/api/columns/{column_id}")
-        return True
+        return self._request("DELETE", f"/api/columns/{column_id}")
 
     def card_create(self, column_id, title, description=None, position=0):
         return self._request(
@@ -119,8 +117,7 @@ class KanbanClient:
         return self._request("PUT", f"/api/cards/{card_id}", json=data)
 
     def card_delete(self, card_id):
-        self._request("DELETE", f"/api/cards/{card_id}")
-        return True
+        return self._request("DELETE", f"/api/cards/{card_id}")
 
     # Organization methods
     def organizations(self):
@@ -149,8 +146,9 @@ class KanbanClient:
         )
 
     def organization_member_remove(self, org_id, user_id):
-        self._request("DELETE", f"/api/organizations/{org_id}/members/{user_id}")
-        return True
+        return self._request(
+            "DELETE", f"/api/organizations/{org_id}/members/{user_id}"
+        )
 
     # Invite methods
     def organization_invite_create(self, org_id, email=None):
@@ -166,8 +164,9 @@ class KanbanClient:
 
     def organization_invite_revoke(self, org_id, invite_id):
         """Revoke an invite."""
-        self._request("DELETE", f"/api/organizations/{org_id}/invites/{invite_id}")
-        return True
+        return self._request(
+            "DELETE", f"/api/organizations/{org_id}/invites/{invite_id}"
+        )
 
     def invite_get(self, token):
         """Get invite details."""
@@ -193,8 +192,7 @@ class KanbanClient:
         return self._request("PUT", f"/api/teams/{team_id}", json={"name": name})
 
     def team_delete(self, team_id):
-        self._request("DELETE", f"/api/teams/{team_id}")
-        return True
+        return self._request("DELETE", f"/api/teams/{team_id}")
 
     def team_members(self, team_id):
         return self._request("GET", f"/api/teams/{team_id}/members")
@@ -205,8 +203,7 @@ class KanbanClient:
         )
 
     def team_member_remove(self, team_id, user_id):
-        self._request("DELETE", f"/api/teams/{team_id}/members/{user_id}")
-        return True
+        return self._request("DELETE", f"/api/teams/{team_id}/members/{user_id}")
 
     # Board sharing
     def board_share(self, board_id, team_id=None):

--- a/kanban/output.py
+++ b/kanban/output.py
@@ -1,0 +1,54 @@
+"""How a command reports its result: formatted for a person, or JSON for a script.
+
+Every command used to print prose only, so scripting meant regexing sentences
+like "Column created with id=17" -- one reworded string broke every caller.
+`emit()` is the fork: a command hands over the API payload plus a callable that
+renders the human version, and the selected mode decides which one is printed.
+"""
+
+import json
+import os
+import sys
+
+from rich import print as rprint
+
+# None means "nobody chose", so fall back to the environment. Set by --json.
+_json_output = None
+
+
+def set_json_output(enabled):
+    global _json_output
+    _json_output = None if enabled is None else bool(enabled)
+
+
+def json_output():
+    """True when results should be printed as JSON.
+
+    KANBAN_OUTPUT is the fallback so a script can set the mode once for a whole
+    run instead of threading --json through every invocation.
+    """
+    if _json_output is not None:
+        return _json_output
+    return os.environ.get("KANBAN_OUTPUT", "").strip().lower() == "json"
+
+
+def emit(payload, render):
+    """Print the raw API `payload` as JSON, or call `render()` for a human."""
+    if json_output():
+        # Plain print, not rich's: rich reflows at the terminal width and
+        # treats square brackets as markup, either of which corrupts JSON.
+        print(json.dumps(payload, indent=2))
+    else:
+        render()
+
+
+def emit_error(message, **extra):
+    """Report a failure, as a JSON object on stderr when that's the mode.
+
+    Errors stay off stdout in JSON mode so a script can parse stdout
+    unconditionally, without first working out whether it holds a result.
+    """
+    if json_output():
+        print(json.dumps({"error": message, **extra}, indent=2), file=sys.stderr)
+    else:
+        rprint(f"[red]{message}[/red]")


### PR DESCRIPTION
Closes #91 on the Dev board.

## The problem

Every command prints for humans only, so scripting means regexing prose. Getting the id of a new column meant `re.search(r"id=(\d+)")` against `Column created with id=17` — one reworded string breaks every script.

## The change

A global `--json` (or `KANBAN_OUTPUT=json`) makes any command print the raw API response instead:

```bash
kanban column create 1 Todo 0 --json | jq -r .id
kanban board get 1 --json | jq '.columns[].cards[] | {id, title, description}'
```

`kanban/output.py` holds the fork: commands hand `emit()` the API payload plus a callable that renders the human version, and the selected mode picks one. Human output is unchanged.

## Three decisions worth a look

1. **The flag works before or after the subcommand.** Click only accepts an option on the command that declares it, so `kanban board list --json` would fail while `kanban --json board list` worked — and the first is what people actually type. `main()` strips it from `argv`, the same trick `--api-key` already uses. A `--json` sitting directly after another option is left alone, since there it's that option's value.
2. **Errors go to stderr** as `{"error": ..., "status": ...}`, never stdout, with the exit code unchanged. A script shouldn't have to determine whether stdout holds a result or an apology before parsing it.
3. **`login --json` omits the access token.** It's already saved to `~/.kanban.yaml`, and stdout is exactly what CI logs capture. This is a deliberate departure from "raw API response".

## Also in here

The client's seven delete methods returned a synthesized `True`, discarding the server's `{"ok": true}`. They now return the real response so JSON mode has something to print.

`docs/commands/` is untouched: the generator introspects subcommands, not root options, so regenerating produces a byte-identical diff. Documented in the README and AGENTS.md instead.

## Testing

10 new tests in `backend/tests/test_cli.py`, including the ticket's own id-extraction case, stdout/stderr separation on failure, and the flag-position edge cases. Full suite: 188 passed, 1 skipped.

Also verified end-to-end against the live server — create board → column → card → delete, every id read from parsed JSON, throwaway board cleaned up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
