### PR TITLE
feat: card get, card move, and column append

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,8 +41,17 @@ The flag works before or after the subcommand. In JSON mode stdout holds only
 the response; errors go to stderr as `{"error": ..., "status": ...}` alongside
 a non-zero exit code, so stdout is always safe to pipe into a parser.
 
-Note there is still no `card get` — a single card's description is only
-reachable through `board get <id> --json`.
+`kanban card get <id>` reads one card, including its description, the comments
+and which board/column it sits on:
+
+```bash
+kanban card get 92 --json | jq -r .description
+```
+
+Note that an unmatched `/api/...` path returns **200 with the SPA's HTML**, not
+a 404 — the catch-all in `backend/main.py` serves index.html for anything it
+does not recognise. A request to an endpoint that does not exist therefore
+looks like a success, which is worth remembering when probing the API by hand.
 
 ## Build, Lint, and Test Commands
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,11 @@ and which board/column it sits on:
 kanban card get 92 --json | jq -r .description
 ```
 
+Two things that used to make seeding a board fiddly are gone: `column create`
+appends when you omit the position, and `card move <id> --column <n>` moves a
+card without retyping its title (on `card update`, anything you don't pass is
+left unchanged).
+
 Note that an unmatched `/api/...` path returns **200 with the SPA's HTML**, not
 a 404 — the catch-all in `backend/main.py` serves index.html for anything it
 does not recognise. A request to an endpoint that does not exist therefore

--- a/README.md
+++ b/README.md
@@ -106,11 +106,12 @@ to `~/.kanban.yaml`, and stdout is what CI logs capture.
 | `kanban board delete <id>` | Delete a board |
 | `kanban board update <id> <name>` | Update board name |
 | `kanban share <board_id> <team_id\|private>` | Share board or make private |
-| `kanban column create <board_id> <name> <position>` | Create a column |
+| `kanban column create <board_id> <name> [position]` | Create a column (appends by default) |
 | `kanban column delete <id>` | Delete a column |
 | `kanban card get <id>` | Show a card's description and comments |
 | `kanban card create <column_id> <title> [options]` | Create a card |
-| `kanban card update <id> <title> [options]` | Update a card |
+| `kanban card update <id> [title] [options]` | Update a card; omitted fields are unchanged |
+| `kanban card move <id> --column <n> [-p <pos>]` | Move a card without touching its text |
 | `kanban card delete <id>` | Delete a card |
 | `kanban org list` | List all organizations |
 | `kanban org create <name>` | Create an organization |

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ to `~/.kanban.yaml`, and stdout is what CI logs capture.
 | `kanban share <board_id> <team_id\|private>` | Share board or make private |
 | `kanban column create <board_id> <name> <position>` | Create a column |
 | `kanban column delete <id>` | Delete a column |
+| `kanban card get <id>` | Show a card's description and comments |
 | `kanban card create <column_id> <title> [options]` | Create a card |
 | `kanban card update <id> <title> [options]` | Update a card |
 | `kanban card delete <id>` | Delete a card |
@@ -208,6 +209,7 @@ The backend exposes a REST API at `/api/`:
 - `DELETE /api/columns/{id}` - Delete column
 
 **Cards**
+- `GET /api/cards/{id}` - Get one card with its description and comments
 - `POST /api/cards` - Create card
 - `PUT /api/cards/{id}` - Update card
 - `DELETE /api/cards/{id}` - Delete card

--- a/backend/api.py
+++ b/backend/api.py
@@ -188,6 +188,20 @@ class CardResponse(BaseModel):
     comments: Optional[list] = []
 
 
+class CardDetailResponse(CardResponse):
+    """A single card, with the column and board it sits on.
+
+    Fetching one card by id is otherwise context-free: the caller knows the id
+    and nothing else, and "which column is this on?" is the question that
+    usually comes right after "what does it say?".
+    """
+
+    column_id: int
+    column_name: str
+    board_id: int
+    board_name: str
+
+
 class CommentCreate(BaseModel):
     card_id: int
     content: str
@@ -1293,6 +1307,45 @@ async def create_card(
         "title": card.title,
         "description": card.description,
         "position": card.position,
+    }
+
+
+@api.get("/cards/{card_id}", response_model=CardDetailResponse)
+async def get_card(
+    card_id: int, current_user: User = Depends(get_current_user_or_api_key)
+):
+    """Read one card. Cards were previously only reachable nested inside a
+    board, so anything holding a card id had no way to see its body."""
+    card = Card.get_or_none(Card.id == card_id)
+    if not card:
+        raise HTTPException(status_code=404, detail="Card not found")
+    if not can_access_board(current_user, card.column.board):
+        raise HTTPException(
+            status_code=403, detail="Not authorized to access this card"
+        )
+
+    comments = Comment.select().where(Comment.card == card).order_by(Comment.created_at)
+    return {
+        "id": card.id,
+        "title": card.title,
+        "description": card.description,
+        "position": card.position,
+        "column_id": card.column.id,
+        "column_name": card.column.name,
+        "board_id": card.column.board.id,
+        "board_name": card.column.board.name,
+        "comments": [
+            {
+                "id": comment.id,
+                "card_id": comment.card.id,
+                "user_id": comment.user.id,
+                "username": comment.user.username,
+                "content": comment.content,
+                "created_at": comment.created_at,
+                "updated_at": comment.updated_at,
+            }
+            for comment in comments
+        ],
     }
 
 

--- a/backend/api.py
+++ b/backend/api.py
@@ -4,6 +4,7 @@ from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.responses import PlainTextResponse
+from peewee import fn
 from pydantic import BaseModel, ConfigDict
 import os
 
@@ -129,7 +130,9 @@ class BoardResponse(BaseModel):
 class ColumnCreate(BaseModel):
     board_id: int
     name: str
-    position: int
+    # Omitted means "append after the last column". Callers were otherwise
+    # made to track an incrementing counter just to add a column at the end.
+    position: Optional[int] = None
 
 
 class ColumnUpdate(BaseModel):
@@ -1204,10 +1207,18 @@ async def create_column(
         raise HTTPException(status_code=404, detail="Board not found")
     if not can_modify_board(current_user, board):
         raise HTTPException(status_code=403, detail="Not authorized")
+    position = column_data.position
+    if position is None:
+        last = (
+            Column.select(fn.MAX(Column.position))
+            .where(Column.board == board)
+            .scalar()
+        )
+        position = 0 if last is None else last + 1
     column = Column.create(
         board=board,
         name=column_data.name,
-        position=column_data.position,
+        position=position,
     )
     return {
         "id": column.id,

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -453,3 +453,62 @@ def test_get_card_does_not_shadow_the_comments_route(client, auth_headers, test_
     response = client.get(f"/api/cards/{card_id}/comments", headers=auth_headers)
     assert response.status_code == 200
     assert response.json() == []
+
+
+def test_create_column_without_position_appends(client, auth_headers, test_user):
+    """position was required, so callers tracked a counter just to add a
+    column at the end."""
+    board_id = client.post(
+        "/api/boards", json={"name": "Append Board"}, headers=auth_headers
+    ).json()["id"]
+
+    first = client.post(
+        "/api/columns",
+        json={"board_id": board_id, "name": "First"},
+        headers=auth_headers,
+    )
+    assert first.status_code == 200
+    assert first.json()["position"] == 0
+
+    second = client.post(
+        "/api/columns",
+        json={"board_id": board_id, "name": "Second"},
+        headers=auth_headers,
+    )
+    assert second.json()["position"] == 1
+
+
+def test_create_column_appends_after_the_highest_position(
+    client, auth_headers, test_user
+):
+    """Append means one past the highest position, not one past the count --
+    positions need not be contiguous."""
+    board_id = client.post(
+        "/api/boards", json={"name": "Sparse Board"}, headers=auth_headers
+    ).json()["id"]
+    client.post(
+        "/api/columns",
+        json={"board_id": board_id, "name": "Far", "position": 9},
+        headers=auth_headers,
+    )
+
+    appended = client.post(
+        "/api/columns",
+        json={"board_id": board_id, "name": "After"},
+        headers=auth_headers,
+    )
+    assert appended.json()["position"] == 10
+
+
+def test_create_column_with_explicit_position_is_unchanged(
+    client, auth_headers, test_user
+):
+    board_id = client.post(
+        "/api/boards", json={"name": "Explicit Board"}, headers=auth_headers
+    ).json()["id"]
+    response = client.post(
+        "/api/columns",
+        json={"board_id": board_id, "name": "Third", "position": 2},
+        headers=auth_headers,
+    )
+    assert response.json()["position"] == 2

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -376,3 +376,80 @@ def test_reorder_columns_requires_auth(client):
         json={"columns": [{"id": 1, "position": 0}]},
     )
     assert response.status_code == 401
+
+
+def test_get_card_returns_description_and_location(client, auth_headers, test_user):
+    """A card's body was previously only reachable nested inside a board, so
+    anything holding a card id could not read what the card said."""
+    board_id = client.post(
+        "/api/boards", json={"name": "Read Card Board"}, headers=auth_headers
+    ).json()["id"]
+    column_id = client.post(
+        "/api/columns",
+        json={"board_id": board_id, "name": "Backlog", "position": 0},
+        headers=auth_headers,
+    ).json()["id"]
+    card_id = client.post(
+        "/api/cards",
+        json={
+            "column_id": column_id,
+            "title": "Has a body",
+            "description": "The part you could not read.",
+            "position": 0,
+        },
+        headers=auth_headers,
+    ).json()["id"]
+
+    response = client.get(f"/api/cards/{card_id}", headers=auth_headers)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["title"] == "Has a body"
+    assert data["description"] == "The part you could not read."
+    # "which column is this on?" is the question right after "what does it say?"
+    assert data["column_id"] == column_id
+    assert data["column_name"] == "Backlog"
+    assert data["board_id"] == board_id
+    assert data["board_name"] == "Read Card Board"
+
+
+def test_get_nonexistent_card_returns_404(client, auth_headers, test_user):
+    response = client.get("/api/cards/99999", headers=auth_headers)
+    assert response.status_code == 404
+    assert "not found" in response.json()["detail"].lower()
+
+
+def test_get_card_on_another_users_board_is_forbidden(client, auth_headers, test_user):
+    """Reading a card must not be a way around board access control."""
+    from backend.models import User, Board, Column, Card
+
+    stranger = User.create_user(
+        username="card-stranger", password="pw", email="stranger@example.com"
+    )
+    board = Board.create_with_columns(owner=stranger, name="Private Board")
+    column = Column.create(board=board, name="Theirs", position=0)
+    card = Card.create(column=column, title="Secret", description="hush", position=0)
+
+    response = client.get(f"/api/cards/{card.id}", headers=auth_headers)
+    assert response.status_code == 403
+
+
+def test_get_card_does_not_shadow_the_comments_route(client, auth_headers, test_user):
+    """GET /cards/{id} is declared before /cards/{id}/comments; the extra path
+    segment must still route to the comments handler."""
+    board_id = client.post(
+        "/api/boards", json={"name": "Route Board"}, headers=auth_headers
+    ).json()["id"]
+    column_id = client.post(
+        "/api/columns",
+        json={"board_id": board_id, "name": "Col", "position": 0},
+        headers=auth_headers,
+    ).json()["id"]
+    card_id = client.post(
+        "/api/cards",
+        json={"column_id": column_id, "title": "Card", "position": 0},
+        headers=auth_headers,
+    ).json()["id"]
+
+    response = client.get(f"/api/cards/{card_id}/comments", headers=auth_headers)
+    assert response.status_code == 200
+    assert response.json() == []

--- a/backend/tests/test_cli.py
+++ b/backend/tests/test_cli.py
@@ -656,3 +656,87 @@ def test_cli_card_get_does_not_interpret_description_as_markup(capsys):
         cmd_card_get(card_id=1)
 
     assert "[bold]" in capsys.readouterr().out
+
+
+def test_cli_card_move_does_not_send_a_title():
+    """The whole point of `card move`: moving used to require retyping the
+    exact title, and one wrong character silently renamed the card."""
+    from kanban.cli import cmd_card_move
+
+    mock_client = MagicMock()
+    mock_client.card_update.return_value = {"id": 7}
+
+    with patch("kanban.cli.make_client", return_value=mock_client):
+        cmd_card_move(card_id=7, column=5, position=None)
+
+    mock_client.card_update.assert_called_once_with(7, None, None, None, 5)
+
+
+def test_cli_card_update_leaves_the_title_alone_when_omitted():
+    from kanban.cli import cmd_card_update
+
+    mock_client = MagicMock()
+    mock_client.card_update.return_value = {"id": 7}
+
+    with patch("kanban.cli.make_client", return_value=mock_client):
+        cmd_card_update(
+            card_id=7, title=None, description=None, position=None, column=5
+        )
+
+    mock_client.card_update.assert_called_once_with(7, None, None, None, 5)
+
+
+def test_client_card_update_omits_unset_fields():
+    """A move must not carry a title, and the endpoint leaves out what it is
+    not sent."""
+    from kanban.client import KanbanClient
+
+    client = KanbanClient(server_url="http://example.test", api_key="k")
+    with patch.object(client, "_request", return_value={}) as request:
+        client.card_update(7, column_id=5)
+
+    assert request.call_args.kwargs["json"] == {"column_id": 5}
+
+
+@pytest.mark.parametrize(
+    "command,kwargs",
+    [
+        ("update", {"title": None, "description": None, "position": None, "column": None}),
+        ("move", {"column": None, "position": None}),
+    ],
+)
+def test_cli_card_change_with_nothing_to_do_errors(command, kwargs):
+    import typer
+    from kanban.cli import cmd_card_update, cmd_card_move
+
+    fn = cmd_card_update if command == "update" else cmd_card_move
+    mock_client = MagicMock()
+
+    with patch("kanban.cli.make_client", return_value=mock_client):
+        with pytest.raises(typer.Exit):
+            fn(card_id=7, **kwargs)
+
+    mock_client.card_update.assert_not_called()
+
+
+def test_cli_column_create_omits_position_to_append():
+    """Omitted position means append; the server works out the number."""
+    from kanban.cli import cmd_column_create
+
+    mock_client = MagicMock()
+    mock_client.column_create.return_value = {"id": 3, "position": 2}
+
+    with patch("kanban.cli.make_client", return_value=mock_client):
+        cmd_column_create(board_id=1, name="Done", position=None)
+
+    mock_client.column_create.assert_called_once_with(1, "Done", None)
+
+
+def test_client_column_create_omits_position_when_appending():
+    from kanban.client import KanbanClient
+
+    client = KanbanClient(server_url="http://example.test", api_key="k")
+    with patch.object(client, "_request", return_value={}) as request:
+        client.column_create(1, "Done")
+
+    assert request.call_args.kwargs["json"] == {"board_id": 1, "name": "Done"}

--- a/backend/tests/test_cli.py
+++ b/backend/tests/test_cli.py
@@ -581,3 +581,78 @@ def test_extract_json_flag_positions(argv, expected_found, expected_argv):
 
     assert _extract_json_flag(argv) is expected_found
     assert argv == expected_argv
+
+
+def test_cli_card_get_shows_the_description(capsys):
+    """`card` had create/update/delete but no way to read a card, so a
+    description was unreachable from the CLI."""
+    from kanban.cli import cmd_card_get
+
+    mock_client = MagicMock()
+    mock_client.card_get.return_value = {
+        "id": 92,
+        "title": "A card",
+        "description": "The body you could not read.",
+        "position": 0,
+        "column_id": 4,
+        "column_name": "Todo",
+        "board_id": 1,
+        "board_name": "Dev",
+        "comments": [],
+    }
+
+    with patch("kanban.cli.make_client", return_value=mock_client):
+        cmd_card_get(card_id=92)
+
+    out = capsys.readouterr().out
+    mock_client.card_get.assert_called_once_with(92)
+    assert "The body you could not read." in out
+    assert "Todo" in out
+
+
+def test_cli_card_get_json_emits_raw_response(capsys, json_mode):
+    import json
+    from kanban.cli import cmd_card_get
+
+    payload = {
+        "id": 92,
+        "title": "A card",
+        "description": "body",
+        "position": 0,
+        "column_id": 4,
+        "column_name": "Todo",
+        "board_id": 1,
+        "board_name": "Dev",
+        "comments": [],
+    }
+    mock_client = MagicMock()
+    mock_client.card_get.return_value = payload
+
+    with patch("kanban.cli.make_client", return_value=mock_client):
+        cmd_card_get(card_id=92)
+
+    assert json.loads(capsys.readouterr().out) == payload
+
+
+def test_cli_card_get_does_not_interpret_description_as_markup(capsys):
+    """Descriptions are user-written text. Rendered as rich markup, a stray
+    tag would silently eat characters -- or blow up on a malformed one."""
+    from kanban.cli import cmd_card_get
+
+    mock_client = MagicMock()
+    mock_client.card_get.return_value = {
+        "id": 1,
+        "title": "t",
+        "description": r"use re.search(r'id=(\d+)') on [bold] output",
+        "position": 0,
+        "column_id": 1,
+        "column_name": "c",
+        "board_id": 1,
+        "board_name": "b",
+        "comments": [],
+    }
+
+    with patch("kanban.cli.make_client", return_value=mock_client):
+        cmd_card_get(card_id=1)
+
+    assert "[bold]" in capsys.readouterr().out

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -71,6 +71,7 @@ Card management commands
 
 - `kanban card create` — Create a new card.
 - `kanban card delete` — Delete a card.
+- `kanban card get` — Show a card's full contents, including its description.
 - `kanban card update` — Update a card.
 
 ## Organization Management

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -72,7 +72,8 @@ Card management commands
 - `kanban card create` — Create a new card.
 - `kanban card delete` — Delete a card.
 - `kanban card get` — Show a card's full contents, including its description.
-- `kanban card update` — Update a card.
+- `kanban card move` — Move a card to another column or position, leaving its text alone.
+- `kanban card update` — Update a card. Anything you don't pass is left unchanged.
 
 ## Organization Management
 

--- a/docs/commands/card.md
+++ b/docs/commands/card.md
@@ -6,6 +6,7 @@ Card management commands
 
 - [`kanban card create`](#kanban-card-create) — Create a new card.
 - [`kanban card delete`](#kanban-card-delete) — Delete a card.
+- [`kanban card get`](#kanban-card-get) — Show a card's full contents, including its description.
 - [`kanban card update`](#kanban-card-update) — Update a card.
 
 ---
@@ -34,6 +35,18 @@ Delete a card.
 
 ```bash
 kanban card delete <card_id>
+```
+
+**Arguments**
+
+- `card_id` (int) — Card ID
+
+## `kanban card get`
+
+Show a card's full contents, including its description.
+
+```bash
+kanban card get <card_id>
 ```
 
 **Arguments**

--- a/docs/commands/card.md
+++ b/docs/commands/card.md
@@ -7,7 +7,8 @@ Card management commands
 - [`kanban card create`](#kanban-card-create) — Create a new card.
 - [`kanban card delete`](#kanban-card-delete) — Delete a card.
 - [`kanban card get`](#kanban-card-get) — Show a card's full contents, including its description.
-- [`kanban card update`](#kanban-card-update) — Update a card.
+- [`kanban card move`](#kanban-card-move) — Move a card to another column or position, leaving its text alone.
+- [`kanban card update`](#kanban-card-update) — Update a card. Anything you don't pass is left unchanged.
 
 ---
 
@@ -53,18 +54,35 @@ kanban card get <card_id>
 
 - `card_id` (int) — Card ID
 
-## `kanban card update`
+## `kanban card move`
 
-Update a card.
+Move a card to another column or position, leaving its text alone.
 
 ```bash
-kanban card update <card_id> <title> [--description DESCRIPTION] [--position POSITION] [--column COLUMN]
+kanban card move <card_id> [--column COLUMN] [--position POSITION]
 ```
 
 **Arguments**
 
 - `card_id` (int) — Card ID
-- `title` (str) — Card title
+
+**Options**
+
+- `--column`, `-c` (int) — Destination column ID
+- `--position`, `-p` (int) — Position within the column
+
+## `kanban card update`
+
+Update a card. Anything you don't pass is left unchanged.
+
+```bash
+kanban card update <card_id> [title] [--description DESCRIPTION] [--position POSITION] [--column COLUMN]
+```
+
+**Arguments**
+
+- `card_id` (int) — Card ID
+- `title` (str) _(optional)_ — New card title. Omit to leave the title alone.
 
 **Options**
 

--- a/docs/commands/column.md
+++ b/docs/commands/column.md
@@ -14,14 +14,14 @@ Column management commands
 Create a new column.
 
 ```bash
-kanban column create <board_id> <name> <position>
+kanban column create <board_id> <name> [position]
 ```
 
 **Arguments**
 
 - `board_id` (int) — Board ID
 - `name` (str) — Column name
-- `position` (int) — Position
+- `position` (int) _(optional)_ — Position. Omit to append after the last column.
 
 ## `kanban column delete`
 

--- a/kanban/cli.py
+++ b/kanban/cli.py
@@ -292,6 +292,36 @@ card_app = typer.Typer(help="Card management commands", no_args_is_help=True)
 app.add_typer(card_app, name="card")
 
 
+@card_app.command("get")
+def cmd_card_get(card_id: int = typer.Argument(..., help="Card ID")):
+    """Show a card's full contents, including its description."""
+    from rich.console import Console
+
+    client = make_client()
+    card = client.card_get(card_id)
+
+    def render():
+        console = Console()
+        console.print(f"[yellow]#{card['id']}[/yellow] [bold]{card['title']}[/bold]")
+        console.print(
+            f"  on {card['board_name']} / {card['column_name']} "
+            f"(column {card['column_id']})"
+        )
+        # The description is user-written text, so hand it to rich as plain
+        # data -- printing it as markup would let a stray [b] eat characters.
+        if card.get("description"):
+            console.print("")
+            console.print(card["description"], markup=False, highlight=False)
+        else:
+            console.print("  [dim](no description)[/dim]")
+        for comment in card.get("comments", []):
+            console.print("")
+            console.print(f"  [cyan]{comment['username']}[/cyan]:")
+            console.print(comment["content"], markup=False, highlight=False)
+
+    emit(card, render)
+
+
 @card_app.command("create")
 def cmd_card_create(
     column_id: int = typer.Argument(..., help="Column ID"),

--- a/kanban/cli.py
+++ b/kanban/cli.py
@@ -268,7 +268,11 @@ app.add_typer(column_app, name="column")
 def cmd_column_create(
     board_id: int = typer.Argument(..., help="Board ID"),
     name: str = typer.Argument(..., help="Column name"),
-    position: int = typer.Argument(..., help="Position"),
+    # Optional rather than an -p option, so the old positional form still
+    # works for anything already calling `column create <board> <name> <pos>`.
+    position: Optional[int] = typer.Argument(
+        None, help="Position. Omit to append after the last column."
+    ),
 ):
     """Create a new column."""
     client = make_client()
@@ -337,21 +341,19 @@ def cmd_card_create(
     emit(result, lambda: rprint(f"Card created with [green]id={result['id']}[/green]"))
 
 
-@card_app.command("update")
-def cmd_card_update(
-    card_id: int = typer.Argument(..., help="Card ID"),
-    title: str = typer.Argument(..., help="Card title"),
-    description: Optional[str] = typer.Option(
-        None, "--description", "-d", help="Card description"
-    ),
-    position: Optional[int] = typer.Option(None, "--position", "-p", help="Position"),
-    column: Optional[int] = typer.Option(None, "--column", "-c", help="New column ID"),
-):
-    """Update a card."""
+def _apply_card_update(card_id, title, description, position, column):
+    """Send a partial card update and report the outcome.
+
+    Shared by `card update` and `card move`, which differ only in which
+    fields they let you name.
+    """
+    if title is None and description is None and position is None and column is None:
+        emit_error("Nothing to change. Pass a title, --description, --position or --column.")
+        raise typer.Exit(1)
+
     client = make_client()
     try:
         result = client.card_update(card_id, title, description, position, column)
-        emit(result, lambda: rprint("[green]Card updated[/green]"))
     except requests.exceptions.HTTPError as e:
         status = e.response.status_code
         if status == 404:
@@ -364,6 +366,43 @@ def cmd_card_update(
             message = f"Error: {e.response.text}"
         emit_error(message, status=status)
         raise typer.Exit(1)
+    emit(result, lambda: rprint("[green]Card updated[/green]"))
+
+
+@card_app.command("update")
+def cmd_card_update(
+    card_id: int = typer.Argument(..., help="Card ID"),
+    # Optional: it used to be required, so moving a card meant retyping its
+    # exact title and one wrong character silently renamed it. Omitted fields
+    # are left alone, which is how --description already behaved.
+    title: Optional[str] = typer.Argument(
+        None, help="New card title. Omit to leave the title alone."
+    ),
+    description: Optional[str] = typer.Option(
+        None, "--description", "-d", help="Card description"
+    ),
+    position: Optional[int] = typer.Option(None, "--position", "-p", help="Position"),
+    column: Optional[int] = typer.Option(None, "--column", "-c", help="New column ID"),
+):
+    """Update a card. Anything you don't pass is left unchanged."""
+    _apply_card_update(card_id, title, description, position, column)
+
+
+@card_app.command("move")
+def cmd_card_move(
+    card_id: int = typer.Argument(..., help="Card ID"),
+    column: Optional[int] = typer.Option(
+        None, "--column", "-c", help="Destination column ID"
+    ),
+    position: Optional[int] = typer.Option(
+        None, "--position", "-p", help="Position within the column"
+    ),
+):
+    """Move a card to another column or position, leaving its text alone."""
+    if column is None and position is None:
+        emit_error("Nothing to move. Pass --column and/or --position.")
+        raise typer.Exit(1)
+    _apply_card_update(card_id, None, None, position, column)
 
 
 @card_app.command("delete")

--- a/kanban/client.py
+++ b/kanban/client.py
@@ -79,12 +79,12 @@ class KanbanClient:
     def board_delete(self, board_id):
         return self._request("DELETE", f"/api/boards/{board_id}")
 
-    def column_create(self, board_id, name, position):
-        return self._request(
-            "POST",
-            "/api/columns",
-            json={"board_id": board_id, "name": name, "position": position},
-        )
+    def column_create(self, board_id, name, position=None):
+        # position is left out entirely when omitted, so the server appends.
+        data = {"board_id": board_id, "name": name}
+        if position is not None:
+            data["position"] = position
+        return self._request("POST", "/api/columns", json=data)
 
     def column_update(self, column_id, name, position):
         return self._request(
@@ -111,10 +111,18 @@ class KanbanClient:
             },
         )
 
-    def card_update(self, card_id, title, description=None, position=0, column_id=None):
-        data = {"title": title, "position": position}
+    def card_update(
+        self, card_id, title=None, description=None, position=None, column_id=None
+    ):
+        # Every field is omitted unless given: the endpoint leaves out what it
+        # is not sent, so a move must not carry a title along with it.
+        data = {}
+        if title is not None:
+            data["title"] = title
         if description is not None:
             data["description"] = description
+        if position is not None:
+            data["position"] = position
         if column_id is not None:
             data["column_id"] = column_id
         return self._request("PUT", f"/api/cards/{card_id}", json=data)

--- a/kanban/client.py
+++ b/kanban/client.py
@@ -96,6 +96,9 @@ class KanbanClient:
     def column_delete(self, column_id):
         return self._request("DELETE", f"/api/columns/{column_id}")
 
+    def card_get(self, card_id):
+        return self._request("GET", f"/api/cards/{card_id}")
+
     def card_create(self, column_id, title, description=None, position=0):
         return self._request(
             "POST",


### PR DESCRIPTION
Closes #92, #93 and #95 on the Dev board.

> **Stacked on #16** — base is `feature/cli-json-output`, so merge that one first. The diff here is just the two commits on top.

Three ergonomics fixes that kept getting in the way while working the board.

## `card get` (#92)

`card` had create, update and delete but no way to *read* one, and `board get` prints titles only — so nothing holding a card id could see what the card said. There was no `GET /api/cards/{id}` either, so this adds one.

It returns the description and comments plus the column and board the card sits on: fetching a card by id is otherwise context-free, and "which column is this on?" is the question that follows "what does it say?". Access goes through `can_access_board`, the same helper the comments endpoint uses — reading a card must not be a way around board permissions.

The CLI renders the description with `markup=False`. Descriptions are user-written text, and a stray `[bold]` would otherwise be swallowed as rich markup — ticket #91's own description contains one.

## `card move` (#93)

Moving a card was `card update <id> <title> --column N`, with the title a **required positional**. You had to already know the card's exact title — and the CLI couldn't tell you what it was, which is why #93 cites the card-get gap. One wrong character silently renamed the card.

`card move <id> --column N [--position P]` names only what it changes. Title is now optional on `card update` too, matching how `--description` already behaved. `CardUpdate` was already all-optional server-side, so this is a client-side fix.

## `column create` appends (#95)

`position` was a required positional, so callers tracked an incrementing counter just to add a column at the end. Omitting it now appends. The server takes `MAX(position) + 1` rather than the column count, since positions need not be contiguous. It stays a positional rather than becoming `-p`, so the existing three-argument form still works.

## Testing

17 new tests across `test_api.py` and `test_cli.py`. Full suite: 205 passed, 1 skipped.

Verified end-to-end against a local server on a scratch database: built a board with three columns and no position argument anywhere, moved a card between columns without typing its title, and confirmed both title and description survived. Both new commands refuse a no-op rather than sending an empty update.

## One thing worth knowing

An unmatched `/api/...` path returns **200 with the SPA's HTML**, not a 404 — the catch-all in `backend/main.py` serves index.html for anything it doesn't recognise. That's what made probing the API by hand misleading, and it's the root of the confusion in #94. A test here pins that `GET /cards/{id}` doesn't shadow `/cards/{id}/comments`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
