### PR TITLE
fix: 404 unknown /api/ paths instead of serving the SPA

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,10 +53,12 @@ appends when you omit the position, and `card move <id> --column <n>` moves a
 card without retyping its title (on `card update`, anything you don't pass is
 left unchanged).
 
-Note that an unmatched `/api/...` path returns **200 with the SPA's HTML**, not
-a 404 — the catch-all in `backend/main.py` serves index.html for anything it
-does not recognise. A request to an endpoint that does not exist therefore
-looks like a success, which is worth remembering when probing the API by hand.
+An unmatched `/api/...` path returns a JSON 404. The SPA catch-all in
+`backend/main.py` is scoped to non-API paths for exactly this reason: it used
+to answer 200 with index.html for anything it did not recognise, so a missing
+endpoint was indistinguishable from a working one and `response.json()` failed
+with a decode error rather than surfacing the 404. Keep that guard in place
+when touching the fallback.
 
 ## Build, Lint, and Test Commands
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,6 +1,6 @@
 import os
 from contextlib import asynccontextmanager
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from fastapi.staticfiles import StaticFiles
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse
@@ -70,6 +70,14 @@ async def root():
 @app.get("/{path:path}")
 async def catch_all(path: str):
     """Serve index.html for all non-API, non-docs routes (SPA fallback)"""
+    # Anything under /api/ reaching the fallback is an endpoint that does not
+    # exist, and the SPA is the wrong answer for it: a 200 of HTML makes a
+    # client's response.json() fail with a decode error rather than see a 404,
+    # and makes a typo'd URL look like a working endpoint when probed by hand.
+    # This is what produced the bad evidence in the auth-inconsistency report.
+    if path == "api" or path.startswith("api/"):
+        raise HTTPException(status_code=404, detail="Not found")
+
     index_path = os.path.join(STATIC_PATH, "index.html")
     if os.path.exists(index_path):
         return FileResponse(index_path)

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -512,3 +512,38 @@ def test_create_column_with_explicit_position_is_unchanged(
         headers=auth_headers,
     )
     assert response.json()["position"] == 2
+
+
+def test_unknown_api_path_returns_json_404_not_the_spa(client):
+    """The SPA catch-all used to answer 200 text/html for any unmatched path,
+    including /api/ ones -- so a missing endpoint looked like a working one,
+    and response.json() raised a decode error instead of surfacing a 404."""
+    response = client.get("/api/definitely-not-a-route")
+    assert response.status_code == 404
+    assert response.headers["content-type"].startswith("application/json")
+    assert response.json()["detail"] == "Not found"
+
+
+def test_bare_api_prefix_returns_404(client):
+    response = client.get("/api")
+    assert response.status_code == 404
+
+
+def test_unknown_api_path_404s_without_credentials_too(client):
+    """A missing endpoint must not be mistakable for an auth failure -- that
+    confusion is what produced the bogus 'boards rejects Bearer, cards accepts
+    it' report, where both 200s were really the catch-all."""
+    response = client.get("/api/cards/14/not-a-thing")
+    assert response.status_code == 404
+    assert response.headers["content-type"].startswith("application/json")
+
+
+def test_real_api_route_still_routes(client, auth_headers, test_user):
+    """The 404 guard must not swallow endpoints that do exist."""
+    assert client.get("/api/boards", headers=auth_headers).status_code == 200
+
+
+def test_non_api_path_still_falls_back_to_the_spa(client):
+    """Front-end routes must keep working: the guard is scoped to /api/."""
+    response = client.get("/some/client/side/route")
+    assert response.status_code == 200


### PR DESCRIPTION
Closes #94 on the Dev board (rewritten — see below).

## The bug

The SPA catch-all in [backend/main.py](backend/main.py) is documented as serving "all non-API, non-docs routes" — but it never checked. Any unmatched path, `/api/` ones included, got **200 and index.html**:

```bash
curl -o /dev/null -w "%{http_code} %{content_type}\n" https://kanban.pearachute.com/api/definitely-not-a-route
```

→ `200 text/html`

So a missing endpoint was indistinguishable from a working one. A client calling `response.json()` on a typo'd URL got a decode error rather than a clean 404, and anyone probing the API by hand read 200 as "this endpoint exists".

## Why #94 said something else

#94 was originally filed as "API auth is inconsistent: /api/boards rejects Bearer, /api/cards accepts it", on this evidence:

```
GET /api/boards      X-API-Key 200   Bearer 401
GET /api/cards/14    X-API-Key 200   Bearer 200
```

That conclusion doesn't hold, and this bug is why:

- **There was no `GET /api/cards/{id}` at the time.** Both 200s on that row were the catch-all answering for a route that didn't exist — for *both* header styles. Not the cards endpoint accepting anything. (That endpoint now exists, added in #17 for ticket #92.)
- **Every boards and cards route takes the same `get_current_user_or_api_key` dependency**, so a per-endpoint auth difference isn't possible. The `/api/boards → 401` was a rejected token, not a rejected header.

I rewrote the ticket to describe the real bug and kept the original evidence in its body with this explanation, so the reasoning isn't lost.

## The fix

Five lines: the catch-all raises a JSON 404 for anything under `/api/`. The guard is scoped to `/api/` so front-end routes still fall back to the SPA. The 404 body uses `detail`, matching the rest of the API — which means the CLI's existing `describe_http_error` renders it as a clean "Not found" rather than a decode traceback.

## Testing

5 new tests: JSON 404 on an unknown API path, on the bare `/api` prefix, and without credentials (pinning that "missing" can't be mistaken for "unauthorized" — the confusion that produced the original report); plus regressions that real API routes still route and non-API paths still reach the SPA. Full suite: 210 passed, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
