### PR TITLE
fix: three bugs found in the pre-release sweep

### DIFF
--- a/backend/tests/test_cli.py
+++ b/backend/tests/test_cli.py
@@ -740,3 +740,42 @@ def test_client_column_create_omits_position_when_appending():
         client.column_create(1, "Done")
 
     assert request.call_args.kwargs["json"] == {"board_id": 1, "name": "Done"}
+
+
+def test_apikey_use_does_not_touch_the_config():
+    """`apikey use` checks a key. It used to clear_token() + set_api_key(),
+    so merely testing a key logged you out and overwrote stored credentials --
+    the same bug #35 fixed for --api-key."""
+    from kanban.cli import cmd_apikey_use
+    from kanban.config import set_token, get_token, get_api_key, clear_api_key
+
+    set_token("my-existing-session")
+    clear_api_key()
+
+    mock_client = MagicMock()
+    mock_client.boards.return_value = [{"id": 1}]
+
+    with patch("kanban.cli.KanbanClient", return_value=mock_client):
+        cmd_apikey_use(key="kanban_probe_key")
+
+    assert get_token() == "my-existing-session"
+    assert get_api_key() is None
+
+
+def test_apikey_use_failure_also_leaves_the_config_alone():
+    import typer
+    from kanban.cli import cmd_apikey_use
+    from kanban.config import set_token, get_token, get_api_key, clear_api_key
+
+    set_token("my-existing-session")
+    clear_api_key()
+
+    mock_client = MagicMock()
+    mock_client.boards.side_effect = Exception("401 Unauthorized")
+
+    with patch("kanban.cli.KanbanClient", return_value=mock_client):
+        with pytest.raises(typer.Exit):
+            cmd_apikey_use(key="kanban_bad_key")
+
+    assert get_token() == "my-existing-session"
+    assert get_api_key() is None

--- a/backend/tests/test_docs_generator.py
+++ b/backend/tests/test_docs_generator.py
@@ -1,0 +1,87 @@
+"""Tests for scripts/generate_cli_docs.py.
+
+CI runs the generator with --check, so anything that makes its output depend
+on the environment rather than on the CLI turns into a spurious failure for
+whoever happens to have a different library version installed.
+"""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(
+    0, os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
+)
+
+from scripts.generate_cli_docs import type_name, is_bool  # noqa: E402
+
+
+class _FakeType:
+    def __init__(self, name):
+        self.name = name
+
+
+class _FakeParam:
+    def __init__(self, name):
+        self.type = _FakeType(name)
+
+
+@pytest.mark.parametrize(
+    "old,new",
+    [
+        # typer 0.15 reported the left name, 0.27 the right one. Both must
+        # render identically or the docs churn on a library upgrade alone.
+        ("text", "str"),
+        ("integer", "int"),
+        ("boolean", "bool"),
+    ],
+)
+def test_type_label_is_the_same_across_typer_versions(old, new):
+    assert type_name(_FakeParam(old)) == type_name(_FakeParam(new))
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("text", "str"),
+        ("str", "str"),
+        ("STRING", "str"),
+        ("integer", "int"),
+        ("int", "int"),
+        ("boolean", "bool"),
+        ("bool", "bool"),
+        ("float", "float"),
+    ],
+)
+def test_type_labels_normalise_to_stable_names(raw, expected):
+    assert type_name(_FakeParam(raw)) == expected
+
+
+def test_unknown_type_falls_back_to_its_own_name():
+    """A type the map doesn't know should still render, just lowercased."""
+    assert type_name(_FakeParam("DateTime")) == "datetime"
+
+
+@pytest.mark.parametrize("raw", ["boolean", "bool"])
+def test_flags_are_detected_under_either_spelling(raw):
+    """usage_line() renders a flag without a value placeholder; missing this
+    on a newer typer would print `[--json JSON]` for a boolean flag."""
+    assert is_bool(_FakeParam(raw)) is True
+
+
+@pytest.mark.parametrize("raw", ["text", "integer", "str", "int"])
+def test_non_flags_are_not_detected_as_flags(raw):
+    assert is_bool(_FakeParam(raw)) is False
+
+
+def test_generated_docs_are_current():
+    """Mirrors CI's `--check` step, so drift fails locally too."""
+    from scripts.generate_cli_docs import build_pages, REPO_ROOT
+
+    for path, content in build_pages().items():
+        target = REPO_ROOT / path
+        assert target.exists(), f"{path.as_posix()} has not been generated"
+        assert target.read_text(encoding="utf-8") == content, (
+            f"{path.as_posix()} is out of date -- run scripts/generate_cli_docs.py"
+        )

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -24,7 +24,7 @@ API key management commands
 - `kanban apikey list` — List all API keys.
 - `kanban apikey revoke` — Revoke (deactivate) an API key.
 - `kanban apikey save` — Save API key to config file for future use.
-- `kanban apikey use` — Run a command using an API key instead of login credentials.
+- `kanban apikey use` — Check that an API key works, without saving it anywhere.
 
 ### [`kanban config`](/docs/commands/config)
 

--- a/docs/commands/apikey.md
+++ b/docs/commands/apikey.md
@@ -9,7 +9,7 @@ API key management commands
 - [`kanban apikey list`](#kanban-apikey-list) — List all API keys.
 - [`kanban apikey revoke`](#kanban-apikey-revoke) — Revoke (deactivate) an API key.
 - [`kanban apikey save`](#kanban-apikey-save) — Save API key to config file for future use.
-- [`kanban apikey use`](#kanban-apikey-use) — Run a command using an API key instead of login credentials.
+- [`kanban apikey use`](#kanban-apikey-use) — Check that an API key works, without saving it anywhere.
 
 ---
 
@@ -71,16 +71,15 @@ kanban apikey save <key>
 
 ## `kanban apikey use`
 
-Run a command using an API key instead of login credentials.
+Check that an API key works, without saving it anywhere.
 
 ```bash
-kanban apikey use <key> [command]
+kanban apikey use <key>
 ```
 
 **Arguments**
 
-- `key` (str) — API key to use
-- `command` (str) _(optional)_ — Command to run with this API key
+- `key` (str) — API key to check
 
 ## See Also
 

--- a/kanban/cli.py
+++ b/kanban/cli.py
@@ -776,35 +776,34 @@ def cmd_apikey_activate(
 
 @apikey_app.command("use")
 def cmd_apikey_use(
-    key: str = typer.Argument(..., help="API key to use"),
-    command: list[str] = typer.Argument(None, help="Command to run with this API key"),
+    key: str = typer.Argument(..., help="API key to check"),
 ):
-    """Run a command using an API key instead of login credentials."""
-    from kanban.config import clear_token, set_api_key
+    """Check that an API key works, without saving it anywhere.
 
-    # Temporarily use this API key
-    clear_token()  # Clear JWT token
-    set_api_key(key)  # Set API key
+    Use 'kanban --api-key <key> <command>' to run a single command with it,
+    or 'kanban apikey save <key>' to store it.
+    """
+    # Nothing here touches the config file. This used to call clear_token()
+    # and set_api_key(), so merely testing a key logged the user out and
+    # overwrote their stored credentials -- the same bug that was fixed for
+    # --api-key, which authenticates through the runtime key instead.
+    client = KanbanClient(api_key=key)
 
     try:
-        # Create a new client with the API key
-        from kanban.client import KanbanClient
-
-        client = KanbanClient(api_key=key)
-
-        # Verify the key works by listing boards
         boards = client.boards()
-
-        def render():
-            rprint(f"[green]API key verified[/green] - found {len(boards)} board(s)")
-            rprint(
-                f"Run your command directly with: [cyan]kanban --api-key {key} <command>[/cyan]"
-            )
-
-        emit({"ok": True, "board_count": len(boards)}, render)
     except Exception as e:
         emit_error(f"API key verification failed: {e}")
         raise typer.Exit(1)
+
+    def render():
+        rprint(f"[green]API key verified[/green] - found {len(boards)} board(s)")
+        rprint(
+            "Run a single command with it: "
+            "[cyan]kanban --api-key <key> <command>[/cyan]"
+        )
+        rprint("Or save it for future use: [cyan]kanban apikey save <key>[/cyan]")
+
+    emit({"ok": True, "board_count": len(boards)}, render)
 
 
 @apikey_app.command("save")

--- a/scripts/generate_cli_docs.py
+++ b/scripts/generate_cli_docs.py
@@ -76,6 +76,36 @@ def split_params(command):
     return arguments, options
 
 
+# click's ParamType.name is not stable across versions: typer 0.15 reports
+# "text"/"integer"/"boolean" where 0.27 reports "str"/"int"/"bool". Reading it
+# raw meant a contributor on a different typer regenerated all 11 pages with
+# spurious type churn, then failed the `--check` step in CI having changed
+# nothing real. Normalising here makes the output depend on the CLI, not on
+# whichever library version happens to be installed.
+TYPE_NAMES = {
+    "text": "str",
+    "string": "str",
+    "str": "str",
+    "integer": "int",
+    "int": "int",
+    "boolean": "bool",
+    "bool": "bool",
+    "float": "float",
+    "number": "float",
+}
+
+
+def type_name(param) -> str:
+    """Stable label for a parameter's type."""
+    raw = (getattr(param.type, "name", "") or "").lower()
+    return TYPE_NAMES.get(raw, raw)
+
+
+def is_bool(param) -> bool:
+    """True for flag-style parameters, which take no value in usage."""
+    return type_name(param) == "bool"
+
+
 def usage_line(path: str, command) -> str:
     """Build the `kanban ...` usage string for a command."""
     arguments, options = split_params(command)
@@ -86,7 +116,7 @@ def usage_line(path: str, command) -> str:
 
     for param in options:
         flag = param.opts[0]
-        if param.type.name == "boolean":
+        if is_bool(param):
             parts.append(flag if param.required else f"[{flag}]")
         else:
             value = param.name.upper()
@@ -105,7 +135,7 @@ def param_lines(command) -> list:
         for param in arguments:
             suffix = "" if param.required else " _(optional)_"
             help_text = f" — {param.help}" if param.help else ""
-            lines.append(f"- `{param.name}` ({param.type.name}){suffix}{help_text}")
+            lines.append(f"- `{param.name}` ({type_name(param)}){suffix}{help_text}")
         lines.append("")
 
     if options:
@@ -115,11 +145,11 @@ def param_lines(command) -> list:
             notes = []
             if param.required:
                 notes.append("required")
-            elif param.default is not None and param.type.name != "boolean":
+            elif param.default is not None and not is_bool(param):
                 notes.append(f"default: `{param.default}`")
             note_text = f" _({', '.join(notes)})_" if notes else ""
             help_text = f" — {param.help}" if param.help else ""
-            lines.append(f"- {flags} ({param.type.name}){note_text}{help_text}")
+            lines.append(f"- {flags} ({type_name(param)}){note_text}{help_text}")
         lines.append("")
 
     return lines

--- a/sys/scripts/deploy.sh
+++ b/sys/scripts/deploy.sh
@@ -11,6 +11,23 @@ NC='\033[0m' # No Color
 # Configuration
 DEPLOY_DIR="/opt/kanban"
 
+# The commit the server was on before this deploy pulled. Change detection has
+# to compare against it rather than HEAD~1: a push of several commits moves
+# HEAD by more than one, so HEAD~1 sees only the final commit of the push. A
+# requirements.txt change in any earlier commit was invisible, and the service
+# restarted without its new dependencies.
+PREVIOUS_SHA=""
+
+# Did anything matching $1 change between the pre-deploy commit and now?
+changed_since_previous() {
+    if [ -z "$PREVIOUS_SHA" ]; then
+        # No baseline to compare against, so do the work rather than silently
+        # skip it -- a needless pip install is cheap, a missing one is not.
+        return 0
+    fi
+    git diff --name-only "$PREVIOUS_SHA" HEAD | grep -q "$1"
+}
+
 echo -e "${GREEN}🚀 Deploying Kanban Board updates${NC}"
 echo "Deploy Directory: $DEPLOY_DIR"
 echo ""
@@ -32,10 +49,13 @@ git_pull() {
     CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
     echo "Current branch: $CURRENT_BRANCH"
 
+    # Captured before the reset, so change detection can see the whole push.
+    PREVIOUS_SHA=$(git rev-parse HEAD)
+
     git fetch origin
     git reset --hard origin/$CURRENT_BRANCH
 
-    echo "Code updated"
+    echo "Code updated ($PREVIOUS_SHA -> $(git rev-parse HEAD))"
 }
 
 # Function to update dependencies (if requirements changed)
@@ -43,7 +63,7 @@ update_dependencies() {
     echo -e "${YELLOW}📦 Checking Python dependencies...${NC}"
 
     # Check if requirements.txt changed
-    if git diff --name-only HEAD~1 HEAD | grep -q "backend/requirements.txt"; then
+    if changed_since_previous "backend/requirements.txt"; then
         echo "Requirements changed, updating..."
         $DEPLOY_DIR/venv/bin/pip install -r $DEPLOY_DIR/backend/requirements.txt
     else
@@ -69,7 +89,7 @@ run_migrations() {
     echo -e "${YELLOW}🗄️ Checking for database migrations...${NC}"
 
     # Check if migration files changed
-    if git diff --name-only HEAD~1 HEAD | grep -q "backend/migrations/"; then
+    if changed_since_previous "backend/migrations/"; then
         echo "Migration files changed, checking database..."
         # Add migration logic here if needed
         echo "Migrations complete"


### PR DESCRIPTION
Bug sweep ahead of cutting the PyPI release. Three unrelated defects, one commit each.

## 1. `apikey use` logs you out and rewrites your config — #106 (new)

Ships in the PyPI package, so this is the one that most needed fixing first.

```python
clear_token()     # wipes the saved JWT -- you are logged out, permanently
set_api_key(key)  # writes the key to ~/.kanban.yaml, permanently
```

The inline comment claimed the key was used "temporarily". Nothing was temporary — both calls write to disk. Running `apikey use` just to *check* whether a key works silently logged you out of your saved session and overwrote your stored credentials.

This is the bug `31890f9` already fixed for `--api-key`. That fix went into `main()`, which routes through `set_runtime_api_key()`; this command built its own client and kept the old behaviour.

Also removed the `command` argument: it was accepted and then silently discarded, so the documented "Run a command using an API key" never happened. `--api-key` covers that properly and the help now says so.

## 2. `deploy.sh` misses changes in multi-commit pushes — #50

`update_dependencies()` ran `git diff HEAD~1 HEAD` *after* `git_pull()` had done `git reset --hard origin/<branch>`. That sees only the final commit of a push, so a `backend/requirements.txt` change in any earlier commit was invisible — `pip install` skipped, service restarted against missing dependencies.

Demonstrated on a scratch repo, three-commit push with the dependency change first:

```
old logic  (HEAD~1 HEAD):   0 matches -> pip install SKIPPED
new logic  ($PREVIOUS_SHA): 1 match   -> pip install RUNS
```

`git_pull()` now records the pre-reset SHA and change detection diffs against that. With no baseline it reports "changed" and does the work — a needless `pip install` is cheap, a missing one is not.

`deploy-production.yml` already documents this exact hazard for its own change detection; the same flaw was here unacknowledged.

## 3. Generated docs depend on the installed typer version — #42

The generator read click's `ParamType.name`, which isn't stable: typer 0.15 reports `text`/`integer`/`boolean`, 0.27 reports `str`/`int`/`bool`. A contributor on a different typer regenerated all 11 pages with spurious churn, then failed CI's `--check` having changed nothing real.

Labels are now normalised inside the generator. Output is byte-identical on typer 0.27, so no docs churn rides along with this.

Found a second instance while there: `usage_line()` and the default-value note both compared against the literal `"boolean"`, already false on 0.27 — a boolean flag would render as `[--flag FLAG]` instead of `[--flag]` as soon as one appeared on a subcommand.

## Testing

21 new tests. Full suite: 231 passed, 1 skipped. `generate_cli_docs.py --check` clean, and the new tests mirror that step so doc drift fails locally too.

## Not included

Triaged the rest of Todo as not-bugs or not-applicable-to-main: #49 (signup isn't on main — that's the `self-serve-signup` branch), #51 (missing test coverage, not a defect), #37 (missing harness), #16/#96 (features), #105 (interface design), #40 (needs reproduction first — the card's own follow-up investigation says the described mechanism doesn't hold).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
