### PR TITLE
fix: resolve the config path per call, not at import

### DIFF
--- a/backend/tests/test_config_isolation.py
+++ b/backend/tests/test_config_isolation.py
@@ -1,0 +1,61 @@
+"""KANBAN_CONFIG_PATH must be honoured whenever it is set.
+
+kanban.config used to bind its path at import time, so the variable only took
+effect if it was set before the first import. A test module importing the CLI
+at collection time -- earlier than any fixture -- silently bound the real
+~/.kanban.yaml, and every subsequent test wrote to the developer's own
+credentials: server URL overwritten, token replaced, API key cleared.
+"""
+
+import os
+from pathlib import Path
+
+# Imported at module scope on purpose: this is the collection-time import that
+# used to freeze the path to the developer's home directory.
+from kanban import config
+
+
+def test_config_path_follows_the_env_var_set_after_import(tmp_path, monkeypatch):
+    target = tmp_path / "late.yaml"
+    monkeypatch.setenv("KANBAN_CONFIG_PATH", str(target))
+
+    config.set_server_url("http://late.example.com")
+
+    assert target.exists()
+    assert config.get_server_url() == "http://late.example.com"
+
+
+def test_writes_never_reach_the_real_home_config(tmp_path, monkeypatch):
+    """The failure this guards against is destructive, so assert the negative
+    directly: nothing may touch ~/.kanban.yaml."""
+    real = config.DEFAULT_CONFIG_FILE
+    before = real.read_bytes() if real.exists() else None
+
+    monkeypatch.setenv("KANBAN_CONFIG_PATH", str(tmp_path / "sandbox.yaml"))
+    config.set_server_url("http://sandbox.example.com")
+    config.set_token("sandbox-token")
+    config.set_api_key("sandbox-key")
+    config.clear_api_key()
+    config.clear_token()
+
+    after = real.read_bytes() if real.exists() else None
+    assert after == before, f"{real} was modified by the test suite"
+
+
+def test_switching_the_env_var_switches_files(tmp_path, monkeypatch):
+    first, second = tmp_path / "a.yaml", tmp_path / "b.yaml"
+
+    monkeypatch.setenv("KANBAN_CONFIG_PATH", str(first))
+    config.set_server_url("http://first.example.com")
+
+    monkeypatch.setenv("KANBAN_CONFIG_PATH", str(second))
+    config.set_server_url("http://second.example.com")
+
+    assert config.get_server_url() == "http://second.example.com"
+    monkeypatch.setenv("KANBAN_CONFIG_PATH", str(first))
+    assert config.get_server_url() == "http://first.example.com"
+
+
+def test_falls_back_to_home_when_unset(monkeypatch):
+    monkeypatch.delenv("KANBAN_CONFIG_PATH", raising=False)
+    assert config.config_file() == Path.home() / ".kanban.yaml"

--- a/kanban/config.py
+++ b/kanban/config.py
@@ -2,7 +2,21 @@ import os
 import yaml
 from pathlib import Path
 
-CONFIG_FILE = Path(os.environ.get("KANBAN_CONFIG_PATH", Path.home() / ".kanban.yaml"))
+DEFAULT_CONFIG_FILE = Path.home() / ".kanban.yaml"
+
+
+def config_file():
+    """Where the config lives, resolved per call rather than at import.
+
+    This used to be a module-level constant, which made KANBAN_CONFIG_PATH
+    effective only if it was set before kanban.config was first imported.
+    Anything importing the CLI earlier than that -- a test module doing so at
+    collection time, before its fixture sets the variable -- silently bound
+    the real ~/.kanban.yaml instead, and every later write landed on the
+    developer's own credentials.
+    """
+    return Path(os.environ.get("KANBAN_CONFIG_PATH", DEFAULT_CONFIG_FILE))
+
 
 # Most installs talk to the hosted service, so default there rather than to a
 # localhost nobody is running -- a fresh `pip install` should reach a real
@@ -12,14 +26,15 @@ DEFAULT_SERVER_URL = "https://kanban.pearachute.com"
 
 
 def ensure_config_dir():
-    CONFIG_FILE.parent.mkdir(parents=True, exist_ok=True)
+    config_file().parent.mkdir(parents=True, exist_ok=True)
 
 
 def load_config():
     ensure_config_dir()
-    if not CONFIG_FILE.exists():
+    path = config_file()
+    if not path.exists():
         return {"server": {"url": DEFAULT_SERVER_URL}, "auth": {}}
-    with open(CONFIG_FILE) as f:
+    with open(path) as f:
         return yaml.safe_load(f) or {
             "server": {"url": DEFAULT_SERVER_URL},
             "auth": {},
@@ -28,7 +43,7 @@ def load_config():
 
 def save_config(config):
     ensure_config_dir()
-    with open(CONFIG_FILE, "w") as f:
+    with open(config_file(), "w") as f:
         yaml.dump(config, f)
 
 


### PR DESCRIPTION
Found the hard way: running the test suite overwrote my own `~/.kanban.yaml`.

## The bug

`kanban/config.py` bound its path at import time:

```python
CONFIG_FILE = Path(os.environ.get("KANBAN_CONFIG_PATH", Path.home() / ".kanban.yaml"))
```

So `KANBAN_CONFIG_PATH` only took effect if it was set **before** the module was first imported.

`test_cli.py` has been getting away with this by accident: every one of its imports sits inside a test function, so the first import of `kanban.config` happens after its autouse fixture has already set the variable. That invariant is invisible and nothing enforced it.

The new `backend/tests/test_docs_generator.py` imports at module scope — `scripts.generate_cli_docs` → `kanban.cli` → `kanban.config` — which happens at **collection time**, before any fixture runs. The path froze to the real `~/.kanban.yaml`, and from then on the entire suite read and wrote the developer's actual credentials: server URL overwritten with `http://localhost:8000`, stored token replaced with a test fixture's string, saved API key cleared.

This is the same class of bug as #31 (pytest wiping the local dev database), which is already in Done. This is the config-file sibling.

## The fix

Resolve the path per call. `DEFAULT_CONFIG_FILE` stays exported for anything that wants the default location.

## Testing

Four tests, all of which **fail against the old implementation** (verified with `HOME` pointed at a sandbox so the check itself couldn't do damage):

- the env var is honoured when set *after* import
- switching the env var switches files
- it falls back to `~/.kanban.yaml` when unset
- **nothing under the suite can modify the home config** — asserted directly against the real path, because this failure mode is destructive rather than merely wrong

Full suite: 235 passed, 1 skipped, with the home config's checksum verified identical before and after the run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
