### PR TITLE
Release 0.2.0

### DIFF
--- a/backend/tests/test_cli.py
+++ b/backend/tests/test_cli.py
@@ -568,12 +568,16 @@ def test_json_login_does_not_print_the_access_token(capsys, json_mode):
         # Typed as a root option, which click would accept anyway.
         (["kanban", "--json", "board", "list"], True, ["kanban", "board", "list"]),
         (["kanban", "board", "list"], False, ["kanban", "board", "list"]),
-        # Following an option, "--json" is that option's value, not our flag.
+        # Following a value-taking option, "--json" is that option's value.
         (
             ["kanban", "card", "create", "1", "t", "--description", "--json"],
             False,
             ["kanban", "card", "create", "1", "t", "--description", "--json"],
         ),
+        # ...but following a flag that takes no value, it is ours. --version is
+        # eager, so missing this printed the human format for --version --json.
+        (["kanban", "--version", "--json"], True, ["kanban", "--version"]),
+        (["kanban", "-V", "--json"], True, ["kanban", "-V"]),
     ],
 )
 def test_extract_json_flag_positions(argv, expected_found, expected_argv):

--- a/kanban/__init__.py
+++ b/kanban/__init__.py
@@ -1,3 +1,3 @@
 """Kanban CLI client for managing boards from the command line."""
 
-__version__ = "0.1.6"
+__version__ = "0.2.0"

--- a/kanban/cli.py
+++ b/kanban/cli.py
@@ -820,6 +820,20 @@ def cmd_apikey_save(key: str = typer.Argument(..., help="API key to save")):
     emit({"ok": True}, render)
 
 
+# Options that consume no value, so a `--json` following one belongs to us
+# rather than to them.
+VALUELESS_FLAGS = frozenset(
+    {
+        "--json",
+        "--version",
+        "-V",
+        "--help",
+        "--install-completion",
+        "--show-completion",
+    }
+)
+
+
 def _extract_json_flag(argv):
     """Pull `--json` off the command line wherever it appears.
 
@@ -828,14 +842,21 @@ def _extract_json_flag(argv):
     failed -- and the second form is the one people type. Strip it here
     instead, the same trick `--api-key` already uses.
 
-    A `--json` sitting right after another option is left alone: there it is
-    that option's value (`--description --json`), not a flag of ours.
+    A `--json` sitting right after a value-taking option is left alone: there
+    it is that option's value (`--description --json`), not a flag of ours.
+    Following a flag that takes no value it is ours, which is why
+    `kanban --version --json` needs VALUELESS_FLAGS below rather than a blanket
+    "preceded by a dash" test.
     """
     found = False
     for i in range(len(argv) - 1, 0, -1):
-        if argv[i] == "--json" and not argv[i - 1].startswith("-"):
-            argv.pop(i)
-            found = True
+        if argv[i] != "--json":
+            continue
+        previous = argv[i - 1]
+        if previous.startswith("-") and previous not in VALUELESS_FLAGS:
+            continue
+        argv.pop(i)
+        found = True
     return found
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pkanban"
-version = "0.1.6"
+version = "0.2.0"
 description = "CLI client for Kanban boards"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
Version bump to 0.2.0, plus one defect the pre-flight turned up.

## Why 0.2.0 rather than 0.1.7

Three new capabilities since 0.1.6 — a global `--json` mode, `card get`, `card move` — plus a behaviour change to `apikey use` (its no-op `command` argument is gone). That's more surface change than the 0.1.x steps carried.

## The pre-flight defect

Building the wheel and driving the installed CLI surfaced this, which the test suite had missed:

```
kanban --version --json   ->  kanban 0.2.0        # wrong: human format
kanban --json --version   ->  {"version": "0.2.0"} # right
```

`_extract_json_flag` skipped any `--json` preceded by a token starting with `-`, assuming it was that option's value. True for `--description --json`; false for flags that take no value. `--version` is eager, so it fired before the `--json` that typer never got to see.

Options that consume no value are now listed explicitly. All three orderings verified against a freshly installed wheel, and the existing tests only covered the value-taking case, so that gap is now closed too.

## Release pre-flight

- `main` clean, 237 passed / 1 skipped
- `generate_cli_docs.py --check` clean
- wheel builds from a clean `git archive` export and **contains `kanban/output.py`** — the new module, which was the main packaging risk
- installed the wheel into a throwaway venv: console entry point works, `card get`/`card move` present in `--help`, `--json` documented, unauthenticated errors render correctly in both modes and go to stderr in JSON mode
- no PEP 585/604 syntax in the shipped package, so the declared `requires-python = ">=3.8"` floor still holds
- `build/` and `dist/` are untracked, so CI builds from clean source

## After merge

Tagging `v0.2.0` triggers `publish-pypi.yml` → PyPI + a GitHub release. Note that workflow does not verify the tag matches the version in `pyproject.toml`; it happens to fail loudly today because PyPI rejects a duplicate version, but that's worth a card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
