### PR TITLE
Fix deploy: dependencies never installed, change detection never had a baseline

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -146,7 +146,17 @@ jobs:
             git config --global user.email "deploy@github.actions"
             git config --global user.name "GitHub Actions"
 
-            # Reset hard to ensure we have the latest code
+            # Captured before the reset below. deploy.sh needs the pre-deploy
+            # commit to tell what changed, and cannot work it out itself: this
+            # step has already moved HEAD by the time it runs, so its own
+            # `git rev-parse HEAD` would return the new commit and every diff
+            # would come back empty. That is what skipped the pip install on
+            # the deploy that added peewee-migrate.
+            PREVIOUS_SHA=$(git rev-parse HEAD)
+
+            # Reset hard to ensure we have the latest code. Done here rather
+            # than leaving it to deploy.sh so that changes to deploy.sh itself
+            # take effect on the deploy that ships them.
             git fetch origin
             git reset --hard origin/main
 
@@ -154,7 +164,7 @@ jobs:
             chmod +x sys/scripts/deploy.sh
 
             # Run the existing deploy script - it handles everything!
-            sys/scripts/deploy.sh
+            DEPLOY_PREVIOUS_SHA="$PREVIOUS_SHA" sys/scripts/deploy.sh
 
       - name: Verify deployment
         run: |

--- a/sys/scripts/deploy.sh
+++ b/sys/scripts/deploy.sh
@@ -50,7 +50,15 @@ git_pull() {
     echo "Current branch: $CURRENT_BRANCH"
 
     # Captured before the reset, so change detection can see the whole push.
-    PREVIOUS_SHA=$(git rev-parse HEAD)
+    #
+    # DEPLOY_PREVIOUS_SHA wins when set. deploy-production.yml does its own
+    # `git reset --hard origin/main` before invoking this script -- so that a
+    # change to this file takes effect on the deploy that ships it, rather than
+    # the one after -- which means HEAD here is already the new commit and
+    # capturing it locally yields an empty diff every time. The workflow passes
+    # the real pre-deploy SHA instead. The fallback covers running this script
+    # by hand.
+    PREVIOUS_SHA="${DEPLOY_PREVIOUS_SHA:-$(git rev-parse HEAD)}"
 
     git fetch origin
     git reset --hard origin/$CURRENT_BRANCH
@@ -62,19 +70,20 @@ git_pull() {
 update_dependencies() {
     echo -e "${YELLOW}📦 Installing Python dependencies...${NC}"
 
-    # Keep this ahead of run_migrations: the migration runner imports
-    # peewee-migrate, so the deploy that introduces a dependency has to install
-    # it before the step that needs it.
+    # Unconditional, deliberately, even though changed_since_previous() is
+    # correct again. The costs are lopsided: a redundant pip install is a few
+    # seconds, a skipped one restarts the service against a missing module.
     #
-    # Gating here is sound now that changed_since_previous() compares against
-    # the pre-pull SHA. It was not when the comparison was `HEAD~1 HEAD`, which
-    # saw only the final commit of a push.
-    if changed_since_previous "backend/requirements.txt"; then
-        echo "Requirements changed, updating..."
-        $DEPLOY_DIR/venv/bin/pip install -r $DEPLOY_DIR/backend/requirements.txt
-    else
-        echo "Requirements unchanged, skipping"
-    fi
+    # This is not hypothetical. The deploy that introduced peewee-migrate
+    # skipped this step and died at run_migrations with ModuleNotFoundError,
+    # because the workflow's own `git reset --hard` had already moved HEAD
+    # before git_pull() captured a baseline, leaving every diff empty.
+    #
+    # It also has to stay ahead of run_migrations, which imports the package
+    # this installs.
+    $DEPLOY_DIR/venv/bin/pip install -q -r $DEPLOY_DIR/backend/requirements.txt
+
+    echo "Dependencies up to date"
 }
 
 # Function to build frontend


### PR DESCRIPTION
The deploy of #15 failed at `run_migrations`:

```
ModuleNotFoundError: No module named 'peewee_migrate'
```

after reporting `Requirements unchanged, skipping` for a push that changed `backend/requirements.txt`. It failed **safely** — `set -e` aborted before `restart_service`, so production kept serving the old code against the old schema — but nothing shipped.

## The baseline was never captured

`git_pull()` records `PREVIOUS_SHA` before its own `git reset --hard`, which is right on its own. But `deploy-production.yml` resets to `origin/main` *itself* before invoking the script, so HEAD is already the new commit when `git_pull()` looks. The log says it plainly:

```
Code updated (701fa892d5 -> 701fa892d5)
```

So every `git diff "$PREVIOUS_SHA" HEAD` was empty and `changed_since_previous()` answered "nothing changed" for every path on every deploy. It only ever worked when `deploy.sh` was run by hand — never through Actions, which is how deploys actually happen.

The workflow now captures the SHA before its reset and passes it as `DEPLOY_PREVIOUS_SHA`; `git_pull()` prefers that, falling back to its own capture. The workflow keeps doing the reset, since that is what makes a change to `deploy.sh` take effect on the deploy that ships it rather than the one after.

Verified against a scratch repo with a three-commit push whose `requirements.txt` change sits in the first commit:

| path | result |
|---|---|
| workflow resets first, passes the SHA | detected |
| `deploy.sh` run by hand | detected |
| old code, for contrast | missed — reproduces this failure |

## Dependencies install unconditionally

Separate decision, and it stands even with detection fixed. The costs are lopsided: a redundant `pip install` is a few seconds, a skipped one restarts the service against a missing module. `run_migrations` imports `peewee-migrate`, so this step cannot be the one that guesses wrong.

`changed_since_previous()` stays and is correct now, but nothing calls it — migrations are deliberately ungated too, since only the `migratehistory` table knows whether a database has pending work. Worth deciding later whether it earns its keep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
