### PR TITLE
Make production.env describe the actual deployment

### DIFF
--- a/sys/config/production.env
+++ b/sys/config/production.env
@@ -1,62 +1,98 @@
 # Production Environment Configuration
-# Copy this file to .env and customize for your environment
+#
+# Template for /opt/kanban/.env, which systemd reads via EnvironmentFile in
+# sys/systemd/kanban.service. Nothing in the deploy creates or updates that
+# file -- copying anything from here is a manual step, and so is restarting
+# the service afterwards.
+#
+# Every variable below is one the code actually reads. If you are looking for
+# a setting that used to be here and is gone, see "Removed" at the bottom.
+#
+# For the current kanban.pearachute.com deployment the only thing this file
+# needs is RESEND_API_KEY. Everything else already has a correct value from
+# the systemd unit or a code default, and setting it again here just creates
+# a second place that can disagree.
 
-# Database Configuration
-DATABASE_PATH=/opt/kanban/data/kanban.db
 
-# Static Files Path (where frontend build files are served from)
-STATIC_PATH=/opt/kanban/backend/static
+# --- Email (Resend) -------------------------------------------------------
+#
+# Used for signup verification links and organization invites.
+#
+# Unset, the app still runs and signup still succeeds -- but mail is printed
+# to the service log instead of sent, so nobody can verify their address and
+# therefore no new account can log in. That failure is invisible from the
+# outside; check `journalctl -u kanban` before believing mail works.
+RESEND_API_KEY=
 
-# Application Configuration
-APP_HOST=127.0.0.1
-APP_PORT=8000
+# Sender address. The domain must be verified in Resend or every send is
+# rejected, silently in the same way.
+#
+# pearachute.com is the apex, and is what is verified. NOT
+# kanban.pearachute.com: Resend treats a subdomain as a separate domain with
+# its own DKIM records. The apex is also what the main site sends from, so
+# both share one domain and one sender reputation.
+#
+# Commented out because backend/mailer.py already defaults to exactly this.
+# Quoted if you do set it: systemd reads values literally to end of line and
+# would not care, but sys/scripts/deploy.sh also reads this file, and an
+# unquoted "Kanban <noreply@...>" is a redirect to anything shell-based.
+# RESEND_FROM="Kanban <noreply@pearachute.com>"
 
-# Security Configuration
+# Origin used to build links inside outgoing email. Deliberately not taken
+# from the request Host header, which is attacker-controlled. Commented out
+# because backend/mailer.py already defaults to exactly this.
+# PUBLIC_BASE_URL=https://kanban.pearachute.com
+
+
+# --- Paths ----------------------------------------------------------------
+#
+# Both of these are already set by Environment= lines in kanban.service, and
+# the unit is the better place for them. Listed here only so the names are
+# discoverable.
+#
+# DATABASE_PATH is worth being careful with. Production is on
+# /opt/kanban/kanban.db. Pointing it somewhere else does not move the data --
+# init_db() creates a fresh empty database at the new path and the app comes
+# up looking wiped. It also relocates the JWT signing key, which
+# backend/auth.py stores in the same directory, invalidating every session.
+#
+# DATABASE_PATH=/opt/kanban/kanban.db
+# STATIC_PATH=/opt/kanban/backend/static
+
+
+# --- Security -------------------------------------------------------------
 #
 # Leave JWT_SECRET_KEY unset and the service generates one on first start and
-# stores it in .jwt_secret next to the database. That is a fine default.
+# stores it in .jwt_secret beside the database. That is a fine default.
 #
-# To manage the key yourself, uncomment the line below and paste in the output
-# of:  python -c "import secrets; print(secrets.token_urlsafe(48))"
+# To manage the key yourself, uncomment below and paste in the output of:
+#   python -c "import secrets; print(secrets.token_urlsafe(48))"
 # The service refuses to start if this is left as an example value -- the repo
 # is public, so a key from it is a key everyone already has.
 #
 # JWT_SECRET_KEY=
-JWT_ALGORITHM=HS256
-JWT_EXPIRE_MINUTES=30
 
-# Logging Configuration
-LOG_LEVEL=info
-
-# CORS Configuration (restrict origins in production)
-CORS_ORIGINS=https://kanban.pearachute.com
-
-# Email Configuration (Resend)
+# Where a generated key is written, if you want it somewhere other than
+# beside the database.
 #
-# Used for signup verification links and organization invites.
-#
-# With RESEND_API_KEY unset the app still works, but mail is not sent -- the
-# message is printed to the service log instead. That is fine for development
-# and it means a missing key never breaks signup, but in production it means
-# nobody can verify their address and therefore nobody can log in.
-#
-# The RESEND_FROM domain must be verified in Resend first, or every send is
-# rejected.
-#
-# Sends from pearachute.com, the apex, which is the domain verified in Resend
-# and the one the main site sends from. NOT kanban.pearachute.com: Resend
-# treats a subdomain as a separate domain needing its own DKIM records, so
-# sending from one that was never added fails every time.
-RESEND_API_KEY=
-# Quoted because of the angle brackets. systemd reads this file literally to
-# end of line and would not care, but deploy.sh also reads it, and an
-# unquoted "Kanban <noreply@...>" is a redirect to anything shell-based.
-RESEND_FROM="Kanban <noreply@pearachute.com>"
+# JWT_SECRET_FILE=/opt/kanban/.jwt_secret
 
-# Origin used to build links in outgoing email. Not taken from the request
-# Host header, which is attacker-controlled.
-PUBLIC_BASE_URL=https://kanban.pearachute.com
 
-# Rate Limiting (optional, for future features)
-# RATE_LIMIT_REQUESTS_PER_MINUTE=60
-# RATE_LIMIT_BURST=100
+# --- Removed ---------------------------------------------------------------
+#
+# These were in this file and nothing read any of them. Three also stated
+# values that were simply untrue of the deployment, which is worse than being
+# absent -- they invited you to trust a number the running service ignores.
+#
+#   APP_HOST, APP_PORT      host and port are hardcoded in the unit's
+#                           ExecStart. The file said 8000; the service listens
+#                           on 8080.
+#   JWT_ALGORITHM           backend/auth.py hardcodes HS256.
+#   JWT_EXPIRE_MINUTES      backend/auth.py hardcodes 60 * 24. The file said
+#                           30, off by a factor of 48.
+#   LOG_LEVEL               nothing reads it; uvicorn's --log-level is not set
+#                           in ExecStart either.
+#   CORS_ORIGINS            backend/main.py hardcodes allow_origins=["*"].
+#                           Restricting origins means changing that code, not
+#                           setting a variable here.
+#   RATE_LIMIT_*            there is no rate limiting anywhere in the stack.


### PR DESCRIPTION
There is no `/opt/kanban/.env` on the server. The unit's `EnvironmentFile` carries a leading `-`, so the service has been starting happily without one and running entirely on `Environment=` lines and code defaults — which meant nobody had reason to read this template closely, and it had drifted into describing a deployment that doesn't exist.

## It would have broken the install

Copying it verbatim — the obvious move when finally creating that file — sets:

```
DATABASE_PATH=/opt/kanban/data/kanban.db
```

Production is on `/opt/kanban/kanban.db`. Pointing the app at the `data/` path doesn't move anything: `init_db()` creates a fresh empty database there and the app comes up **looking wiped**. It also relocates the JWT signing key, which `backend/auth.py` stores in the database's directory, invalidating every session.

## Six settings were read by nothing

Verified by grep across `backend/`, `manage.py`, `kanban/`, `sys/` and `.github/` — zero references each:

| setting | reality |
|---|---|
| `APP_HOST`, `APP_PORT` | hardcoded in the unit's `ExecStart` |
| `JWT_ALGORITHM` | `backend/auth.py` hardcodes `HS256` |
| `JWT_EXPIRE_MINUTES` | `backend/auth.py` hardcodes `60 * 24` |
| `LOG_LEVEL` | nothing reads it |
| `CORS_ORIGINS` | `backend/main.py` hardcodes `allow_origins=["*"]` |
| `RATE_LIMIT_*` | no rate limiting exists |

Three also stated values untrue of the running service — port `8000` against an actual `8080`, token lifetime `30` minutes against an actual 24 hours, and the database path above. **A setting that lies is worse than one that's absent**, because it invites you to trust a number the service ignores.

## What it looks like now

Only variables the code reads. Which ones the systemd unit already sets and should keep owning, so there aren't two places that can disagree. And the removals stay visible at the bottom with what replaced them, so this doesn't read as an unexplained deletion later.

For the current deployment the only thing the file needs is `RESEND_API_KEY` — now the single uncommented line.

Checked that `deploy.sh`'s `DATABASE_PATH` lookup still behaves against the new file: the commented-out line correctly doesn't match, resolution falls back to `/opt/kanban/kanban.db`, and the file is still safe for anything shell-based to read.

## Follow-up

CORS deserves its own look — `allow_origins=["*"]` with `allow_credentials=True` is a combination browsers reject outright, and the config implied an origin allowlist that was never implemented. Filed as card #110 rather than fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
