### PR TITLE
Fix homepage demo crashing with a TypeError on every cycle

### DIFF
--- a/frontend/src/components/TerminalSimulator.svelte
+++ b/frontend/src/components/TerminalSimulator.svelte
@@ -2,12 +2,17 @@
   import { onMount, onDestroy } from 'svelte';
   import { executeCommand, getDemoState } from '$lib/demoApi';
 
-  // Demo command sequence - uses actual CLI syntax
+  // Demo command sequence - uses actual CLI syntax.
+  //
+  // The card id has to match what `card create` actually returns against
+  // demoApi's initial state, which seeds cards 1-3 and so hands out 4. These
+  // referenced card 12, which never existed: both update commands failed with
+  // "Card 12 not found" on every run.
   const DEMO_COMMANDS = [
     'kanban board get 1',
     'kanban card create 1 "Fix API latency"',
-    'kanban card update 12 "Fix API latency" --column 2',
-    'kanban card update 12 "Fix API latency" --description "Optimize DB queries"'
+    'kanban card update 4 "Fix API latency" --column 2',
+    'kanban card update 4 "Fix API latency" --description "Optimize DB queries"'
   ];
 
 let displayedText = '';
@@ -44,10 +49,14 @@ const RESET_PAUSE = 2000; // Longer pause during reset to make it more noticeabl
       // Command complete - execute it
       showOutput = true;
       const result = executeCommand(currentCommand);
-      outputLines = result.stdout.split('\n');
+      // demoApi returns stderr instead of stdout on a failed command, so
+      // reading .stdout unconditionally threw a TypeError and killed the
+      // animation. Show whichever the command produced.
+      const output = result.stdout ?? result.stderr ?? '';
+      outputLines = output.split('\n');
       commandHistory = [...commandHistory, {
         command: currentCommand,
-        output: result.stdout,
+        output,
         exitCode: result.exitCode
       }];
 


### PR DESCRIPTION
The landing page terminal animation died partway through on **every page load**, about ten seconds in, and never reached the last two commands it exists to show off:

```
Uncaught TypeError: Cannot read properties of undefined (reading 'split')
```

Two faults, stacked.

## The demo asked for a card that never existed

`DEMO_COMMANDS` updates card **12**. But `demoApi`'s initial state seeds cards 1–3 with `lastCardId: 3`, so `card create` hands back id **4**. Both update commands failed with `Error: Card 12 not found` every single run.

## Which then took the page down

That alone would have been a quiet cosmetic bug — the demo silently showing errors. It became an exception because `demoApi` returns `stderr` and *no* `stdout` on a failed command, while `TerminalSimulator` read `result.stdout` unconditionally before calling `.split` on it.

So the first failing command killed the animation instead of printing its error.

Both are fixed: the id matches what `create` actually returns, and the simulator falls back to `stderr`. **The second half is the one that matters** — it stops a data mistake in the demo script from becoming an uncaught exception on the marketing homepage.

## Verification

Ran the `DEMO_COMMANDS` sequence through `demoApi` in node, replicating `TerminalSimulator.svelte:47` verbatim:

| command | before | after |
|---|---|---|
| `board get 1` | stdout present | stdout present |
| `card create 1 "Fix API latency"` | stdout present | stdout present |
| `card update … --column 2` | **stdout UNDEFINED → TypeError** | stdout present |
| `card update … --description …` | **stdout UNDEFINED → TypeError** | stdout present |

The reproduced error is character-for-character the one from the browser.

Then confirmed against a local build in a browser: console stays clean across several full animation cycles (~15s each), where it previously threw within about ten seconds and again every cycle. The terminal renders `Card created with id=4`, which is the id mismatch made visible.

## Not from the signup work

These files were last touched by `eeebd86` and `d895c3e`. This has been live for a while — it just isn't something you'd notice without the console open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
