### PR TITLE
Deploy installs the systemd unit when it changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -311,3 +311,35 @@ kanban/
 ├── pyproject.toml       # Project config & package metadata
 └── pyrightconfig.json   # Type checking config
 ```
+### Deploying systemd and nginx config
+
+`deploy.sh` installs `sys/systemd/kanban.service` itself when it differs from
+`/etc/systemd/system/kanban.service`, then `daemon-reload`s before restarting.
+On an unchanged unit it is a no-op and needs no sudo.
+
+This needs three narrow sudoers rules, written by `install.sh`:
+
+```
+kanban ALL=(ALL) NOPASSWD: /bin/systemctl restart kanban
+kanban ALL=(ALL) NOPASSWD: /bin/systemctl daemon-reload
+kanban ALL=(ALL) NOPASSWD: /bin/cp /opt/kanban/sys/systemd/kanban.service /etc/systemd/system/kanban.service
+```
+
+If they are missing, a deploy carrying a unit change **fails** rather than
+restarting onto the stale unit. That is deliberate. Before this existed, a unit
+edit reached the repo and the box but never the running service and said
+nothing about it — `EnvironmentFile=-/opt/kanban/.env` sat unapplied long
+enough that `RESEND_API_KEY` was set correctly and still ignored, so signup
+returned 201 and sent no mail.
+
+Two things that make this class of bug hard to see:
+
+- `systemctl show kanban --property=Environment` does **not** expand
+  `EnvironmentFile` contents, so it looks identical whether the file is read or
+  not. Use `--property=EnvironmentFiles`, `systemctl cat kanban`, or read
+  `/proc/$(systemctl show kanban --property=MainPID --value)/environ`.
+- The leading `-` in `EnvironmentFile=-` makes a missing or unread file
+  non-fatal by design, so nothing complains.
+
+`sys/nginx/kanban.pearachute.com.conf` is still installed by hand — the deploy
+does not touch it.

--- a/sys/scripts/deploy.sh
+++ b/sys/scripts/deploy.sh
@@ -141,6 +141,62 @@ run_migrations() {
     echo "Migrations complete"
 }
 
+# Function to install the systemd unit when it has changed
+install_unit() {
+    echo -e "${YELLOW}⚙️ Checking systemd unit...${NC}"
+
+    REPO_UNIT="$DEPLOY_DIR/sys/systemd/kanban.service"
+    LIVE_UNIT="/etc/systemd/system/kanban.service"
+
+    if [ ! -f "$REPO_UNIT" ]; then
+        echo "No unit file in the repo, skipping"
+        return 0
+    fi
+
+    # The common case: nothing to do, and no sudo needed to find that out.
+    if cmp -s "$REPO_UNIT" "$LIVE_UNIT"; then
+        echo "Unit unchanged"
+        return 0
+    fi
+
+    if [ -f "$LIVE_UNIT" ]; then
+        echo "Installed unit differs from the repo:"
+        diff "$LIVE_UNIT" "$REPO_UNIT" || true
+    else
+        echo "No unit installed yet, installing for the first time"
+    fi
+
+    # -n so a missing sudoers rule fails immediately instead of blocking on a
+    # password prompt that nothing can answer.
+    if sudo -n cp "$REPO_UNIT" "$LIVE_UNIT" 2>/dev/null &&
+       sudo -n systemctl daemon-reload 2>/dev/null; then
+        echo "Unit installed, systemd reloaded"
+        return 0
+    fi
+
+    # Deliberately fatal. Restarting now would come up on the stale unit and
+    # report success, which is the exact failure this step exists to end: an
+    # EnvironmentFile line sat in the repo for weeks while the running service
+    # knew nothing about it, so /opt/kanban/.env was never read and signup
+    # sent no mail while looking healthy.
+    echo -e "${RED}❌ Cannot install the unit -- deploy user lacks sudo rights${NC}"
+    echo ""
+    echo "Grant them once, as root:"
+    echo "  cat > /etc/sudoers.d/kanban-restart <<'EOF'"
+    echo "kanban ALL=(ALL) NOPASSWD: /bin/systemctl restart kanban"
+    echo "kanban ALL=(ALL) NOPASSWD: /bin/systemctl daemon-reload"
+    echo "kanban ALL=(ALL) NOPASSWD: /bin/cp $REPO_UNIT $LIVE_UNIT"
+    echo "EOF"
+    echo "  chmod 440 /etc/sudoers.d/kanban-restart"
+    echo ""
+    echo "Or apply this one change by hand and re-run the deploy:"
+    echo "  sudo cp $REPO_UNIT $LIVE_UNIT"
+    echo "  sudo systemctl daemon-reload"
+    echo ""
+    echo "Check what is currently permitted with: sudo -n -l"
+    exit 1
+}
+
 # Function to restart service
 restart_service() {
     echo -e "${YELLOW}🔄 Restarting kanban service...${NC}"
@@ -175,7 +231,11 @@ main() {
     echo -e "${GREEN}Step 4: Run migrations${NC}"
     run_migrations
 
-    echo -e "${GREEN}Step 5: Restart service${NC}"
+    # Before the restart, so the restart is what picks up a changed unit.
+    echo -e "${GREEN}Step 5: Install systemd unit${NC}"
+    install_unit
+
+    echo -e "${GREEN}Step 6: Restart service${NC}"
     restart_service
 
     echo ""

--- a/sys/scripts/install.sh
+++ b/sys/scripts/install.sh
@@ -191,11 +191,37 @@ setup_nginx() {
 setup_sudoers() {
     echo -e "${YELLOW}🔐 Setting up sudoers permissions...${NC}"
 
-    # Allow kanban user to restart the service without password
-    echo "kanban ALL=(ALL) NOPASSWD: /bin/systemctl restart kanban" > /etc/sudoers.d/kanban-restart
+    # Three narrowly scoped rules, no blanket NOPASSWD:
+    #   restart          - what deploy.sh has always needed
+    #   daemon-reload    - and the cp below, so deploy.sh can install a changed
+    #   cp <exact args>    unit itself. Without these a unit edit reaches the
+    #                      repo and the box but never the running service, and
+    #                      says nothing about it -- which is how EnvironmentFile
+    #                      went unapplied long enough for /opt/kanban/.env to be
+    #                      silently ignored.
+    #
+    # The cp rule pins both paths, so it grants exactly "install this project's
+    # unit file" and not "copy anything anywhere". Note it does let anyone who
+    # can write $DEPLOY_DIR/sys/systemd/kanban.service choose what the unit
+    # says, including User=root -- acceptable here only because pushing to main
+    # already runs arbitrary code as this user. Do not widen it further.
+    cat > /etc/sudoers.d/kanban-restart <<EOF
+kanban ALL=(ALL) NOPASSWD: /bin/systemctl restart kanban
+kanban ALL=(ALL) NOPASSWD: /bin/systemctl daemon-reload
+kanban ALL=(ALL) NOPASSWD: /bin/cp $DEPLOY_DIR/sys/systemd/kanban.service /etc/systemd/system/kanban.service
+EOF
     chmod 440 /etc/sudoers.d/kanban-restart
 
-    echo "Sudoers configured - kanban can restart service without password"
+    # A malformed sudoers file locks out every rule in it, including the
+    # restart that deploys depend on. Fail the install rather than discover
+    # that on the next deploy.
+    if ! visudo -c -f /etc/sudoers.d/kanban-restart; then
+        echo -e "${RED}Sudoers file is invalid, removing it${NC}"
+        rm -f /etc/sudoers.d/kanban-restart
+        exit 1
+    fi
+
+    echo "Sudoers configured - kanban can restart, daemon-reload, and install the unit"
 }
 
 # Function to setup SSL with Let's Encrypt


### PR DESCRIPTION
Nothing in the deploy has ever been able to update `/etc/systemd/system/kanban.service`. `deploy.sh` only ran `systemctl restart`, so a unit edit reached the repo, passed CI, deployed green, and had no effect on the running service — indefinitely, and without saying so.

Not hypothetical. `EnvironmentFile=-/opt/kanban/.env` was added to the repo unit in `3645023`. The installed unit predated it and was never updated, so `/opt/kanban/.env` was never read at all — `RESEND_API_KEY` was set correctly in that file and the mailer still reported it missing, while signup returned `201 Created` and sent nothing.

Two details kept it hidden:

- the leading `-` in `EnvironmentFile=-` makes an unread file non-fatal **by design**, so nothing complains
- `systemctl show --property=Environment` reports only literal `Environment=` lines and never expands `EnvironmentFile`, so its output is identical whether the file is read or not

## What changes

`deploy.sh` compares the two files before restarting and installs the repo copy when they differ.

**Unchanged is the common path** — `cmp` needs no privileges, so a normal deploy adds one file comparison and nothing else.

When they differ and sudo won't allow the install, **the deploy fails** rather than restarting onto the stale unit, printing the sudoers block and the manual commands. Failing loudly is the whole point; silence is what made the original bug expensive.

`install.sh` grows two sudoers rules alongside the existing restart:

```
kanban ALL=(ALL) NOPASSWD: /bin/systemctl restart kanban
kanban ALL=(ALL) NOPASSWD: /bin/systemctl daemon-reload
kanban ALL=(ALL) NOPASSWD: /bin/cp /opt/kanban/sys/systemd/kanban.service /etc/systemd/system/kanban.service
```

The `cp` pins both paths, so it grants "install this project's unit" rather than "copy anything anywhere". It also runs `visudo -c` and removes the file if invalid — a malformed sudoers drop-in disables every rule in it, including the restart deploys depend on.

## The tradeoff, stated plainly

This lets anyone who can write `sys/systemd/kanban.service` decide what the unit says, `User=root` included. That's acceptable **only** because pushing to main already runs arbitrary code as the kanban user via `deploy.sh` itself, so it isn't a new trust boundary — just a shorter path across an existing one. It shouldn't be widened further.

## Verification

Logic exercised against five cases with a stubbed sudo:

| case | result |
|---|---|
| unit unchanged | no-op, no sudo invoked |
| changed, sudo permitted | installs, live matches repo |
| changed, sudo denied | exits nonzero, live unit untouched, restart never reached |
| no unit in the repo | skips |
| no unit installed yet | creates it |

## For this box

The existing sudoers file has only the restart rule, so the next deploy will hit the "cannot install" path and stop before restarting. Add the rules once as root — the deploy prints the exact block — and it self-heals from then on. Or apply that one `cp` by hand first; either way the deploy after it is a no-op.

Closes the deploy half of card #112. The nginx config is still installed by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
